### PR TITLE
Versioned entities

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
         "nelmio/cors-bundle": "^2.3",
         "phpdocumentor/reflection-docblock": "^5.3",
         "phpstan/phpdoc-parser": "^1.24",
+        "stof/doctrine-extensions-bundle": "^1.11",
         "subiabre/doctrine-snowflakes": "^2.0",
         "symfony/asset": "6.4.*",
         "symfony/console": "6.4.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b558cc67d1647e5cfb49487057a3af3d",
+    "content-hash": "e65a6d86be5982961b544a7bfa7704c9",
     "packages": [
         {
             "name": "api-platform/core",
@@ -171,6 +171,55 @@
                 "source": "https://github.com/api-platform/core/tree/v3.2.14"
             },
             "time": "2024-02-20T09:52:06+00:00"
+        },
+        {
+            "name": "behat/transliterator",
+            "version": "v1.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Behat/Transliterator.git",
+                "reference": "baac5873bac3749887d28ab68e2f74db3a4408af"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Behat/Transliterator/zipball/baac5873bac3749887d28ab68e2f74db3a4408af",
+                "reference": "baac5873bac3749887d28ab68e2f74db3a4408af",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "chuyskywalker/rolling-curl": "^3.1",
+                "php-yaoi/php-yaoi": "^1.0",
+                "phpunit/phpunit": "^8.5.25 || ^9.5.19"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Behat\\Transliterator\\": "src/Behat/Transliterator"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Artistic-1.0"
+            ],
+            "description": "String transliterator",
+            "keywords": [
+                "i18n",
+                "slug",
+                "transliterator"
+            ],
+            "support": {
+                "issues": "https://github.com/Behat/Transliterator/issues",
+                "source": "https://github.com/Behat/Transliterator/tree/v1.5.0"
+            },
+            "time": "2022-03-30T09:27:43+00:00"
         },
         {
             "name": "brick/math",
@@ -1608,6 +1657,134 @@
             "time": "2022-05-23T21:33:49+00:00"
         },
         {
+            "name": "gedmo/doctrine-extensions",
+            "version": "v3.15.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine-extensions/DoctrineExtensions.git",
+                "reference": "2a89103f4984d8970f3855284c8c04e6e6a63c0f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine-extensions/DoctrineExtensions/zipball/2a89103f4984d8970f3855284c8c04e6e6a63c0f",
+                "reference": "2a89103f4984d8970f3855284c8c04e6e6a63c0f",
+                "shasum": ""
+            },
+            "require": {
+                "behat/transliterator": "^1.2",
+                "doctrine/collections": "^1.2 || ^2.0",
+                "doctrine/common": "^2.13 || ^3.0",
+                "doctrine/deprecations": "^1.0",
+                "doctrine/event-manager": "^1.2 || ^2.0",
+                "doctrine/persistence": "^2.2 || ^3.0",
+                "php": "^7.4 || ^8.0",
+                "psr/cache": "^1 || ^2 || ^3",
+                "psr/clock": "^1",
+                "symfony/cache": "^5.4 || ^6.0 || ^7.0"
+            },
+            "conflict": {
+                "doctrine/annotations": "<1.13 || >=3.0",
+                "doctrine/dbal": "<3.2 || >=4.0",
+                "doctrine/mongodb-odm": "<2.3 || >=3.0",
+                "doctrine/orm": "<2.14.0 || 2.16.0 || 2.16.1 || >=3.0"
+            },
+            "require-dev": {
+                "doctrine/annotations": "^1.13 || ^2.0",
+                "doctrine/cache": "^1.11 || ^2.0",
+                "doctrine/dbal": "^3.2",
+                "doctrine/doctrine-bundle": "^2.3",
+                "doctrine/mongodb-odm": "^2.3",
+                "doctrine/orm": "^2.14.0",
+                "friendsofphp/php-cs-fixer": "^3.14.0",
+                "nesbot/carbon": "^2.71 || ^3.0",
+                "phpstan/phpstan": "^1.10.2",
+                "phpstan/phpstan-doctrine": "^1.0",
+                "phpstan/phpstan-phpunit": "^1.0",
+                "phpunit/phpunit": "^9.6",
+                "rector/rector": "^0.19",
+                "symfony/console": "^5.4 || ^6.0 || ^7.0",
+                "symfony/phpunit-bridge": "^6.0 || ^7.0",
+                "symfony/yaml": "^5.4 || ^6.0 || ^7.0"
+            },
+            "suggest": {
+                "doctrine/mongodb-odm": "to use the extensions with the MongoDB ODM",
+                "doctrine/orm": "to use the extensions with the ORM"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.13-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Gedmo\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Gediminas Morkevicius",
+                    "email": "gediminas.morkevicius@gmail.com"
+                },
+                {
+                    "name": "Gustavo Falco",
+                    "email": "comfortablynumb84@gmail.com"
+                },
+                {
+                    "name": "David Buchmann",
+                    "email": "david@liip.ch"
+                }
+            ],
+            "description": "Doctrine behavioral extensions",
+            "homepage": "http://gediminasm.org/",
+            "keywords": [
+                "Blameable",
+                "behaviors",
+                "doctrine",
+                "extensions",
+                "gedmo",
+                "loggable",
+                "nestedset",
+                "odm",
+                "orm",
+                "sluggable",
+                "sortable",
+                "timestampable",
+                "translatable",
+                "tree",
+                "uploadable"
+            ],
+            "support": {
+                "email": "gediminas.morkevicius@gmail.com",
+                "issues": "https://github.com/doctrine-extensions/DoctrineExtensions/issues",
+                "source": "https://github.com/doctrine-extensions/DoctrineExtensions/tree/v3.15.0",
+                "wiki": "https://github.com/Atlantic18/DoctrineExtensions/tree/main/doc"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/l3pp4rd",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/mbabker",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/phansys",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/stof",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-02-12T15:17:22+00:00"
+        },
+        {
             "name": "godruoyi/php-snowflake",
             "version": "3.0.0",
             "source": {
@@ -2353,6 +2530,86 @@
                 "source": "https://github.com/php-fig/log/tree/3.0.0"
             },
             "time": "2021-07-14T16:46:02+00:00"
+        },
+        {
+            "name": "stof/doctrine-extensions-bundle",
+            "version": "v1.11.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/stof/StofDoctrineExtensionsBundle.git",
+                "reference": "9f7023e4c8a1c00a5627d41c1027a3f89e477630"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/stof/StofDoctrineExtensionsBundle/zipball/9f7023e4c8a1c00a5627d41c1027a3f89e477630",
+                "reference": "9f7023e4c8a1c00a5627d41c1027a3f89e477630",
+                "shasum": ""
+            },
+            "require": {
+                "gedmo/doctrine-extensions": "^3.15.0",
+                "php": "^7.4 || ^8.0",
+                "symfony/cache": "^5.4 || ^6.0 || ^7.0",
+                "symfony/config": "^5.4 || ^6.0 || ^7.0",
+                "symfony/dependency-injection": "^5.4 || ^6.0 || ^7.0",
+                "symfony/event-dispatcher": "^5.4 || ^6.0 || ^7.0",
+                "symfony/http-kernel": "^5.4 || ^6.0 || ^7.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.10",
+                "phpstan/phpstan-deprecation-rules": "^1.1",
+                "phpstan/phpstan-phpunit": "^1.3",
+                "phpstan/phpstan-strict-rules": "^1.5",
+                "phpstan/phpstan-symfony": "^1.3",
+                "symfony/mime": "^5.4 || ^6.0 || ^7.0",
+                "symfony/phpunit-bridge": "^v6.4.1 || ^7.0.1",
+                "symfony/security-core": "^5.4 || ^6.0 || ^7.0"
+            },
+            "suggest": {
+                "doctrine/doctrine-bundle": "to use the ORM extensions",
+                "doctrine/mongodb-odm-bundle": "to use the MongoDB ODM extensions",
+                "symfony/mime": "To use the Mime component integration for Uploadable"
+            },
+            "type": "symfony-bundle",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Stof\\DoctrineExtensionsBundle\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christophe Coevoet",
+                    "email": "stof@notk.org"
+                }
+            ],
+            "description": "Integration of the gedmo/doctrine-extensions with Symfony",
+            "homepage": "https://github.com/stof/StofDoctrineExtensionsBundle",
+            "keywords": [
+                "behaviors",
+                "doctrine2",
+                "extensions",
+                "gedmo",
+                "loggable",
+                "nestedset",
+                "sluggable",
+                "sortable",
+                "timestampable",
+                "translatable",
+                "tree"
+            ],
+            "support": {
+                "issues": "https://github.com/stof/StofDoctrineExtensionsBundle/issues",
+                "source": "https://github.com/stof/StofDoctrineExtensionsBundle/tree/v1.11.0"
+            },
+            "time": "2024-02-13T14:43:20+00:00"
         },
         {
             "name": "subiabre/doctrine-snowflakes",

--- a/config/bundles.php
+++ b/config/bundles.php
@@ -11,4 +11,5 @@ return [
     Symfony\Bundle\MakerBundle\MakerBundle::class => ['dev' => true],
     Zenstruck\Foundry\ZenstruckFoundryBundle::class => ['dev' => true, 'test' => true],
     Symfony\Bundle\MonologBundle\MonologBundle::class => ['all' => true],
+    Stof\DoctrineExtensionsBundle\StofDoctrineExtensionsBundle::class => ['all' => true],
 ];

--- a/config/packages/doctrine.yaml
+++ b/config/packages/doctrine.yaml
@@ -21,6 +21,12 @@ doctrine:
                 dir: '%kernel.project_dir%/src/Entity'
                 prefix: 'App\Entity'
                 alias: App
+            
+            gedmo_loggable:
+                type: attribute
+                prefix: Gedmo\Loggable\Entity
+                dir: "%kernel.project_dir%/vendor/gedmo/doctrine-extensions/src/Loggable/Entity"
+                is_bundle: false
 
 when@test:
     doctrine:

--- a/config/packages/stof_doctrine_extensions.yaml
+++ b/config/packages/stof_doctrine_extensions.yaml
@@ -1,0 +1,8 @@
+# Read the documentation: https://symfony.com/doc/current/bundles/StofDoctrineExtensionsBundle/index.html
+# See the official DoctrineExtensions documentation for more details: https://github.com/doctrine-extensions/DoctrineExtensions/tree/main/doc
+stof_doctrine_extensions:
+    default_locale: en_US
+
+    orm:
+        default:
+            loggable: true

--- a/src/ApiResource/Version.php
+++ b/src/ApiResource/Version.php
@@ -3,9 +3,13 @@
 namespace App\ApiResource;
 
 use ApiPlatform\Metadata as API;
+use App\Filter\VersionResourceFilter;
+use App\Filter\VersionResourceIdFilter;
 use App\State\VersionStateProvider;
 use Gedmo\Loggable\Entity\LogEntry;
 
+#[API\ApiFilter(VersionResourceFilter::class, properties: ['resource'])]
+#[API\ApiFilter(VersionResourceIdFilter::class, properties: ['resourceId'])]
 #[API\GetCollection(provider: VersionStateProvider::class)]
 #[API\Get(provider: VersionStateProvider::class)]
 class Version

--- a/src/ApiResource/Version.php
+++ b/src/ApiResource/Version.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\ApiResource;
+
+use ApiPlatform\Metadata as API;
+use App\State\VersionStateProvider;
+use Gedmo\Loggable\Entity\LogEntry;
+
+#[API\GetCollection(provider: VersionStateProvider::class)]
+#[API\Get(provider: VersionStateProvider::class)]
+class Version
+{
+    public function __construct(
+        private readonly LogEntry $log,
+        private readonly object $entity
+    ) {
+    }
+
+    public function getId(): ?int
+    {
+        return $this->log->getId();
+    }
+
+    public function getVersion(): ?int
+    {
+        return $this->log->getVersion();
+    }
+
+    public function getAction(): ?string
+    {
+        return $this->log->getAction();
+    }
+
+    public function getResource(): string
+    {
+        $classPieces = explode('\\', $this->log->getObjectClass());
+
+        return end($classPieces);
+    }
+
+    public function getResouceId(): int
+    {
+        return $this->log->getObjectId();
+    }
+
+    public function getResourceData()
+    {
+        $entity = $this->entity;
+
+        foreach ($this->log->getData() as $changedProperty => $changedValue) {
+            $setter = sprintf("set%s", ucfirst($changedProperty));
+            $entity->$setter($changedValue);
+        }
+
+        return $entity;
+    }
+
+    public function getResourceChanges()
+    {
+        return $this->log->getData();
+    }
+
+    public function getDateCreated(): ?\DateTimeInterface
+    {
+        return $this->log->getLoggedAt();
+    }
+}

--- a/src/ApiResource/Version.php
+++ b/src/ApiResource/Version.php
@@ -8,6 +8,12 @@ use App\Filter\VersionResourceIdFilter;
 use App\State\VersionStateProvider;
 use Gedmo\Loggable\Entity\LogEntry;
 
+/**
+ * Some resources are versioned. This means v4 keeps track of the changes performed in subsets of specific properties within these resources.\
+ * \
+ * This allows us to keep track of the flow and the evolution of records in the platform.
+ * Looking at the changes done between one version and the next one we can reconstruct how a resource was at a certain point in time.
+ */
 #[API\ApiFilter(VersionResourceFilter::class, properties: ['resource'])]
 #[API\ApiFilter(VersionResourceIdFilter::class, properties: ['resourceId'])]
 #[API\GetCollection(provider: VersionStateProvider::class)]
@@ -20,21 +26,33 @@ class Version
     ) {
     }
 
+    /**
+     * The ID of the version record.
+     */
     public function getId(): ?int
     {
         return $this->log->getId();
     }
 
+    /**
+     * The ID of the version for this specific resource.
+     */
     public function getVersion(): ?int
     {
         return $this->log->getVersion();
     }
 
+    /**
+     * The type of action that performed the recorded changes.
+     */
     public function getAction(): ?string
     {
         return $this->log->getAction();
     }
 
+    /**
+     * The type of the recorded resource.
+     */
     public function getResource(): string
     {
         $classPieces = explode('\\', $this->log->getObjectClass());
@@ -42,11 +60,17 @@ class Version
         return end($classPieces);
     }
 
+    /**
+     * The ID of the recorded resource.
+     */
     public function getResouceId(): int
     {
         return $this->log->getObjectId();
     }
 
+    /**
+     * The full resource data, reconstructed from the current resource data merged with versioned data.
+     */
     public function getResourceData()
     {
         $entity = $this->entity;
@@ -59,11 +83,17 @@ class Version
         return $entity;
     }
 
+    /**
+     * The changed resource data, i.e the new values of the changed properties.
+     */
     public function getResourceChanges()
     {
         return $this->log->getData();
     }
 
+    /**
+     * The date at which this version was created.
+     */
     public function getDateCreated(): ?\DateTimeInterface
     {
         return $this->log->getLoggedAt();

--- a/src/Entity/Interface/UserOwnedInterface.php
+++ b/src/Entity/Interface/UserOwnedInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Entity\Interface;
+
+use App\Entity\User;
+
+interface UserOwnedInterface
+{
+    public function getOwner(): ?User;
+
+    public function isOwnedBy(User $user): bool;
+}

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -157,7 +157,7 @@ class User implements UserInterface, UserOwnedInterface, PasswordAuthenticatedUs
     {
         return (string) $this->username;
     }
-    
+
     public function getOwner(): ?User
     {
         return $this;

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -72,7 +72,7 @@ class User implements UserInterface, UserOwnedInterface, PasswordAuthenticatedUs
      */
     #[Assert\NotBlank(['groups' => ['postValidation']])]
     #[Assert\Length(min: 12)]
-    #[API\ApiProperty(writable: true, readable: false)]
+    #[API\ApiProperty(writable: true, readable: false, required: true)]
     #[SerializedName('password')]
     private ?string $plainPassword = null;
 

--- a/src/Entity/UserToken.php
+++ b/src/Entity/UserToken.php
@@ -4,6 +4,7 @@ namespace App\Entity;
 
 use ApiPlatform\Metadata as API;
 use App\Dto\UserTokenLoginDto;
+use App\Entity\Interface\UserOwnedInterface;
 use App\Repository\UserTokenRepository;
 use App\State\UserTokenLoginProcessor;
 use Doctrine\ORM\Mapping as ORM;
@@ -18,9 +19,10 @@ use Doctrine\ORM\Mapping as ORM;
  * `pat_` means the token was created via a login flow.
  */
 #[API\Post(input: UserTokenLoginDto::class, processor: UserTokenLoginProcessor::class)]
-#[API\Delete(security: 'is_granted("AUTH_OWNER")')]
+#[API\Get(security: 'is_granted("USER_OWNED", object)')]
+#[API\Delete(security: 'is_granted("USER_OWNED", object)')]
 #[ORM\Entity(repositoryClass: UserTokenRepository::class)]
-class UserToken
+class UserToken implements UserOwnedInterface
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
@@ -38,7 +40,7 @@ class UserToken
      */
     #[ORM\ManyToOne(inversedBy: 'tokens')]
     #[ORM\JoinColumn(nullable: false)]
-    private ?User $ownedBy = null;
+    private ?User $owner = null;
 
     public function getId(): ?int
     {
@@ -57,20 +59,20 @@ class UserToken
         return $this;
     }
 
-    public function getOwnedBy(): ?User
+    public function getOwner(): ?User
     {
-        return $this->ownedBy;
+        return $this->owner;
     }
 
-    public function setOwnedBy(?User $ownedBy): static
+    public function setOwner(?User $owner): static
     {
-        $this->ownedBy = $ownedBy;
+        $this->owner = $owner;
 
         return $this;
     }
 
     public function isOwnedBy(User $user): bool
     {
-        return $this->ownedBy->getUserIdentifier() === $user->getUserIdentifier();
+        return $this->owner->getUserIdentifier() === $user->getUserIdentifier();
     }
 }

--- a/src/Filter/VersionResourceFilter.php
+++ b/src/Filter/VersionResourceFilter.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Filter;
+
+use ApiPlatform\Doctrine\Orm\Filter\AbstractFilter;
+use ApiPlatform\Doctrine\Orm\Util\QueryNameGeneratorInterface;
+use ApiPlatform\Metadata\Operation;
+use Doctrine\ORM\QueryBuilder;
+use Doctrine\Persistence\ManagerRegistry;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\PropertyInfo\Type;
+use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
+
+final class VersionResourceFilter extends AbstractFilter
+{
+    public function __construct(
+        protected ManagerRegistry $managerRegistry,
+        ?LoggerInterface $logger = null,
+        protected ?array $properties = null,
+        protected ?NameConverterInterface $nameConverter = null
+    ) {
+        parent::__construct($managerRegistry, $logger, $properties, $nameConverter);
+    }
+
+    protected function filterProperty(
+        string $property,
+        $value,
+        QueryBuilder $queryBuilder,
+        QueryNameGeneratorInterface $queryNameGenerator,
+        string $resourceClass,
+        Operation $operation = null,
+        array $context = []
+    ): void {
+        return;
+    }
+
+    public function getDescription(string $resourceClass): array
+    {
+        $description = [];
+        foreach ($this->properties as $property => $strategy) {
+            $description["$property"] = [
+                'property' => $property,
+                'type' => Type::BUILTIN_TYPE_STRING,
+                'required' => true,
+                'description' => 'The name of the resource.',
+                'schema' => [
+                    'type' => Type::BUILTIN_TYPE_STRING,
+                    'enum' => ['User']
+                ],
+                'openapi' => [
+                    'allowEmptyValue' => false,
+                ],
+            ];
+        }
+
+        return $description;
+    }
+}

--- a/src/Filter/VersionResourceIdFilter.php
+++ b/src/Filter/VersionResourceIdFilter.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Filter;
+
+use ApiPlatform\Doctrine\Orm\Filter\AbstractFilter;
+use ApiPlatform\Doctrine\Orm\Util\QueryNameGeneratorInterface;
+use ApiPlatform\Metadata\Operation;
+use Doctrine\ORM\QueryBuilder;
+use Symfony\Component\PropertyInfo\Type;
+
+final class VersionResourceIdFilter extends AbstractFilter
+{
+    protected function filterProperty(
+        string $property,
+        $value,
+        QueryBuilder $queryBuilder,
+        QueryNameGeneratorInterface $queryNameGenerator,
+        string $resourceClass,
+        Operation $operation = null,
+        array $context = []
+    ): void {
+        return;
+    }
+
+    public function getDescription(string $resourceClass): array
+    {
+        $description = [];
+        foreach ($this->properties as $property => $strategy) {
+            $description["$property"] = [
+                'property' => $property,
+                'type' => Type::BUILTIN_TYPE_INT,
+                'required' => true,
+                'description' => 'The ID of the named resource.',
+                'openapi' => [
+                    'allowEmptyValue' => false,
+                ],
+            ];
+        }
+
+        return $description;
+    }
+}

--- a/src/Security/AccessTokenHandler.php
+++ b/src/Security/AccessTokenHandler.php
@@ -21,6 +21,6 @@ class AccessTokenHandler implements AccessTokenHandlerInterface
             throw new BadCredentialsException();
         }
 
-        return new UserBadge($token->getOwnedBy()->getUserIdentifier());
+        return new UserBadge($token->getOwner()->getUserIdentifier());
     }
 }

--- a/src/Security/Voter/UserOwnedVoter.php
+++ b/src/Security/Voter/UserOwnedVoter.php
@@ -2,21 +2,28 @@
 
 namespace App\Security\Voter;
 
+use App\Entity\Interface\UserOwnedInterface;
+use App\Entity\User;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\Voter;
 use Symfony\Component\Security\Core\User\UserInterface;
 
-class AuthOwnerVoter extends Voter
+class UserOwnedVoter extends Voter
 {
-    public const OWNER = 'AUTH_OWNER';
+    public const OWNED = 'USER_OWNED';
 
     protected function supports(string $attribute, mixed $subject): bool
     {
-        return in_array($attribute, [self::OWNER])
-            && $subject !== null
-            && method_exists($subject, 'isOwnedBy');
+        if (!in_array($attribute, [self::OWNED])) {
+            return false;
+        }
+
+        return $subject instanceof UserOwnedInterface;
     }
 
+    /**
+     * @param User|UserOwnedInterface $subject
+     */
     protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token): bool
     {
         $user = $token->getUser();
@@ -27,7 +34,5 @@ class AuthOwnerVoter extends Voter
         }
 
         return $subject->isOwnedBy($user);
-
-        return false;
     }
 }

--- a/src/Security/Voter/UserVoter.php
+++ b/src/Security/Voter/UserVoter.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Security\Voter;
+
+use App\Entity\User;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\Voter;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+class UserVoter extends Voter
+{
+    public const EDIT = 'USER_EDIT';
+    public const VIEW = 'USER_VIEW';
+
+    protected function supports(string $attribute, mixed $subject): bool
+    {
+        return in_array($attribute, [self::EDIT, self::VIEW])
+            && $subject instanceof User;
+    }
+
+    /**
+     * @param User $subject
+     */
+    protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token): bool
+    {
+        $user = $token->getUser();
+
+        if (!$user instanceof UserInterface) {
+            return false;
+        }
+
+        switch ($attribute) {
+            case self::EDIT:
+                return $user->getUserIdentifier() === $subject->getUserIdentifier()
+                    || \in_array('ROLE_ADMIN', $user->getRoles());
+            case self::VIEW:
+                return true;
+        }
+
+        return false;
+    }
+}

--- a/src/Service/Auth/AuthService.php
+++ b/src/Service/Auth/AuthService.php
@@ -28,7 +28,7 @@ class AuthService
     {
         $token = new UserToken;
 
-        $token->setOwnedBy($user);
+        $token->setOwner($user);
         $token->setToken(sprintf('%s%s', $type->value, hash(
             self::TOKEN_HASH_ALGO,
             join('', [

--- a/src/State/VersionStateProvider.php
+++ b/src/State/VersionStateProvider.php
@@ -49,7 +49,7 @@ class VersionStateProvider implements ProviderInterface
 
     private function getVersions(string $resource, int $resourceId)
     {
-        $entity = $this->entityManager->find(sprintf("App\\Entity\\%s", $resource), $resourceId);
+        $entity = $this->entityManager->find($this->resourceToEntity($resource), $resourceId);
         $logs = $this->versionRepository->getLogEntries($entity);
 
         $versions = [];
@@ -58,5 +58,10 @@ class VersionStateProvider implements ProviderInterface
         }
 
         return $versions;
+    }
+
+    private function resourceToEntity(string $resource): string
+    {
+        return sprintf("App\\Entity\\%s", ucfirst(strtolower($resource)));
     }
 }

--- a/src/State/VersionStateProvider.php
+++ b/src/State/VersionStateProvider.php
@@ -34,7 +34,10 @@ class VersionStateProvider implements ProviderInterface
         }
     }
 
-    private function getVersion(int $id)
+    /**
+     * @throws NotFoundHttpException
+     */
+    private function getVersion(int $id): Version
     {
         $log = $this->versionRepository->find($id);
 
@@ -47,7 +50,10 @@ class VersionStateProvider implements ProviderInterface
         return new Version($log, $entity);
     }
 
-    private function getVersions(string $resource, int $resourceId)
+    /**
+     * @return Version[]
+     */
+    private function getVersions(string $resource, int $resourceId): array
     {
         $entity = $this->entityManager->find($this->resourceToEntity($resource), $resourceId);
         $logs = $this->versionRepository->getLogEntries($entity);

--- a/src/State/VersionStateProvider.php
+++ b/src/State/VersionStateProvider.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\State;
+
+use ApiPlatform\Metadata as API;
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProviderInterface;
+use App\ApiResource\Version;
+use Doctrine\ORM\EntityManagerInterface;
+use Gedmo\Loggable\Entity\LogEntry;
+use Gedmo\Loggable\Entity\Repository\LogEntryRepository;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+class VersionStateProvider implements ProviderInterface
+{
+    private LogEntryRepository $versionRepository;
+
+    public function __construct(
+        private EntityManagerInterface $entityManager
+    ) {
+        $this->versionRepository = $this->entityManager->getRepository(LogEntry::class);
+    }
+
+    public function provide(Operation $operation, array $uriVariables = [], array $context = []): object|array|null
+    {
+        switch ($operation::class) {
+            case API\Get::class:
+                return $this->getVersion($uriVariables['id']);
+            case API\GetCollection::class:
+                return $this->getVersions(
+                    $context['request']->query->get('resource'),
+                    $context['request']->query->get('resourceId')
+                );
+        }
+    }
+
+    private function getVersion(int $id)
+    {
+        $log = $this->versionRepository->find($id);
+
+        if (!$log) {
+            throw new NotFoundHttpException("Not Found");
+        }
+
+        $entity = $this->entityManager->find($log->getObjectClass(), $log->getObjectId());
+
+        return new Version($log, $entity);
+    }
+
+    private function getVersions(string $resource, int $resourceId)
+    {
+        $entity = $this->entityManager->find(sprintf("App\\Entity\\%s", $resource), $resourceId);
+        $logs = $this->versionRepository->getLogEntries($entity);
+
+        $versions = [];
+        foreach ($logs as $log) {
+            $versions[] = new Version($log, $entity);
+        }
+
+        return $versions;
+    }
+}

--- a/symfony.lock
+++ b/symfony.lock
@@ -66,6 +66,18 @@
             "tests/bootstrap.php"
         ]
     },
+    "stof/doctrine-extensions-bundle": {
+        "version": "1.11",
+        "recipe": {
+            "repo": "github.com/symfony/recipes-contrib",
+            "branch": "main",
+            "version": "1.2",
+            "ref": "e805aba9eff5372e2d149a9ff56566769e22819d"
+        },
+        "files": [
+            "config/packages/stof_doctrine_extensions.yaml"
+        ]
+    },
     "symfony/console": {
         "version": "6.3",
         "recipe": {


### PR DESCRIPTION
This PR adds support for versioned entities. It uses the [Loggable extension from the DoctrineExtensions](https://github.com/doctrine-extensions/DoctrineExtensions/blob/main/doc/loggable.md) library to do so. When one of the versioned properties of an entity changes, it records that change into a separate table in the database that can be used as a version repository.

1. Update the db schema: `doctrine:schema:update --force`
2. Try updating your own email or username via an API call
3. Check the record in the `ext_log_entries` table.