### PR TITLE
Project entity

### DIFF
--- a/src/Entity/Project.php
+++ b/src/Entity/Project.php
@@ -50,10 +50,6 @@ class Project
     #[ORM\Column(type: 'string', enumType: Status::class)]
     private Status $status;
 
-    #[API\ApiProperty(writable: false)]
-    #[ORM\Column(type: 'int')]
-    private ?Money $amount;
-
     use TimestampableEntity;
 
     public function __construct()
@@ -113,17 +109,5 @@ class Project
     public function getStatus(): Status
     {
         return $this->status;
-    }
-
-    public function setAmount(int $amount): static
-    {
-        $this->amount = $amount;
-
-        return $this;
-    }
-
-    public function getAmount(): int
-    {
-        return $this->amount;
     }
 }

--- a/src/Entity/Project.php
+++ b/src/Entity/Project.php
@@ -7,7 +7,7 @@ use ApiPlatform\Metadata as API;
 use App\Repository\ProjectRepository;
 use App\Entity\ProjectStatus as Status;
 use Doctrine\ORM\Mapping as ORM;
-use Doctrine\ORM\Mapping\Entity;
+use Gedmo\Timestampable\Traits\TimestampableEntity;
 
 /**
  * Projects describe a community-led event that is to be discovered, developed and funded by other Users.\
@@ -53,6 +53,8 @@ class Project
     #[Orm\Column()]
     #[API\ApiProperty(writable: false)]
     private int $amount;
+
+    use TimestampableEntity;
 
     public function __construct()
     {
@@ -108,7 +110,7 @@ class Project
         return $this;
     }
 
-    public function getStatus(): string
+    public function getStatus(): Status
     {
         return $this->status;
     }

--- a/src/Entity/Project.php
+++ b/src/Entity/Project.php
@@ -5,7 +5,9 @@ namespace App\Entity;
 use ApiPlatform\Doctrine\Orm\Filter\SearchFilter;
 use ApiPlatform\Metadata as API;
 use App\Repository\ProjectRepository;
+use App\Entity\ProjectStatus as Status;
 use Doctrine\ORM\Mapping as ORM;
+use Doctrine\ORM\Mapping\Entity;
 
 /**
  * Projects describe a community-led event that is to be discovered, developed and funded by other Users.\
@@ -19,7 +21,10 @@ use Doctrine\ORM\Mapping as ORM;
 #[API\Put(security: 'is_granted("AUTH_PROJECT_EDIT")')]
 #[API\Delete(security: 'is_granted("AUTH_PROJECT_EDIT")')]
 #[API\Patch(security: 'is_granted("AUTH_PROJECT_EDIT")')]
-#[API\ApiFilter(filterClass: SearchFilter::class, properties: ['title' => 'partial'])]
+#[API\ApiFilter(filterClass: SearchFilter::class, properties: [
+    'title' => 'partial',
+    'status', 'owner'
+])]
 #[ORM\Entity(repositoryClass: ProjectRepository::class)]
 class Project
 {
@@ -35,6 +40,19 @@ class Project
     #[ORM\OneToOne(cascade: ['persist', 'remove'])]
     #[ORM\JoinColumn(nullable: false)]
     private ?Accounting $accounting = null;
+
+    #[API\ApiProperty(writable: false)]
+    #[ORM\OneToOne(cascade: ['persist', 'remove'])]
+    #[ORM\JoinColumn(nullable: false)]
+    private User $owner;
+
+    #[API\ApiProperty(writable: true)]
+    #[ORM\Column(type: 'int', enumType: Status::class)]
+    private Status $status;
+
+    #[Orm\Column()]
+    #[API\ApiProperty(writable: false)]
+    private int $amount;
 
     public function __construct()
     {
@@ -69,5 +87,41 @@ class Project
         $this->accounting = $accounting;
 
         return $this;
+    }
+
+    public function setOwner(User $owner): static
+    {
+        $this->owner = $owner;
+
+        return $this;
+    }
+
+    public function getOwner(): User
+    {
+        return $this->owner;
+    }
+
+    public function setStatus(string $status): static
+    {
+        $this->status = $status;
+
+        return $this;
+    }
+
+    public function getStatus(): string
+    {
+        return $this->status;
+    }
+
+    public function setAmount(int $amount): static
+    {
+        $this->amount = $amount;
+
+        return $this;
+    }
+
+    public function getAmount(): int
+    {
+        return $this->amount;
     }
 }

--- a/src/Entity/Project.php
+++ b/src/Entity/Project.php
@@ -47,7 +47,7 @@ class Project
     private User $owner;
 
     #[API\ApiProperty(writable: true)]
-    #[ORM\Column(type: 'int', enumType: Status::class)]
+    #[ORM\Column(type: 'string', enumType: Status::class)]
     private Status $status;
 
     #[API\ApiProperty(writable: false)]

--- a/src/Entity/Project.php
+++ b/src/Entity/Project.php
@@ -50,9 +50,9 @@ class Project
     #[ORM\Column(type: 'int', enumType: Status::class)]
     private Status $status;
 
-    #[Orm\Column()]
     #[API\ApiProperty(writable: false)]
-    private int $amount;
+    #[ORM\Column(type: 'int')]
+    private ?Money $amount;
 
     use TimestampableEntity;
 

--- a/src/Entity/ProjectStatus.php
+++ b/src/Entity/ProjectStatus.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Entity;
+
+enum ProjectStatus: int
+{
+    case REJECTED = 0;
+    case EDITING = 1;
+    case REVIEWING = 2;
+    case IN_CAMPAIGN = 3;
+    case FUNDED = 4;
+    case FULFILLED = 5;
+    case UNFUNDED = 6;
+}

--- a/src/Entity/ProjectStatus.php
+++ b/src/Entity/ProjectStatus.php
@@ -2,13 +2,13 @@
 
 namespace App\Entity;
 
-enum ProjectStatus: int
+enum ProjectStatus: string
 {
-    case REJECTED = 0;
-    case EDITING = 1;
-    case REVIEWING = 2;
-    case IN_CAMPAIGN = 3;
-    case FUNDED = 4;
-    case FULFILLED = 5;
-    case UNFUNDED = 6;
+    case Rejected = 'rejected';
+    case Editing = 'editing';
+    case Reviewing = 'reviewing';
+    case InCampaign = 'in_campaign';
+    case Funded = 'funded';
+    case Fulfilled = 'fulfilled';
+    case Unfunded = 'unfunded';
 }


### PR DESCRIPTION
Add all the necessary fields for the Project entity.

Comming from the Project model of V3 we have this fields in the Project table

```
id
name
subtitle
lang
currency
currency_rate
status
translate
progress
owner
node
amount
mincost
maxcost
days
num_investors
popularity
num_messengers
num_posts
created
updated
published
success
closed
passed
contract_name
contract_nif
phone
contract_email
address
zipcode
location
country
image
description
motivation
video
video_usubs
about
goal
related
spread
reward
category
keywords
media
media_usubs
currently
project_location
scope
resource
comment
contract_entity
contract_birthdate
entity_office
entity_name
entity_cif
post_address
secondary_address
post_zipcode
post_location
post_country
amount_users
amount_call
maxproj
analytics_id
facebook_pixel
social_commitment
social_commitment_description
execution_plan
sustainability_model
execution_plan_url
sustainability_model_url
sign_url
sign_url_action
```

Some of this fields are inside data for the project (i.e id, owner, etc), some are related to the presentation of the project (i.e, subtitle, description, motivation, etc), also we have some fiscal information in the model (all the fields related to contract)

This has to end now.

We also have some tables with information about a project
```
project
project_account
project_bot
project_category
project_conf
project_data
project_image
project_lang
project_location
project_milestone
project_open_tag
```

This tables will have to be reconfigured.

Right now, the new entity will have fewer details inside it, and we will handle better the configuration aspects of a campaign, as well as their fields to aggregate data and show it to the user.

This PR will use the following new fields
```
owner
status
created_at
modified_at
amount
```

To handle the status of the `Project` we will use a `ProjectStatus` enum.

THIS IS A WIP