### PR TITLE
[FIX] Update pumps configuration interface

### DIFF
--- a/src/Library/Benzina/Pump/AbstractPump.php
+++ b/src/Library/Benzina/Pump/AbstractPump.php
@@ -4,9 +4,9 @@ namespace App\Library\Benzina\Pump;
 
 abstract class AbstractPump implements PumpInterface
 {
-    protected ?array $config;
+    protected array $config;
 
-    public function configure(?array $config = null): void
+    public function configure(array $config = []): void
     {
         $this->config = $config;
     }

--- a/src/Library/Benzina/Pump/PumpInterface.php
+++ b/src/Library/Benzina/Pump/PumpInterface.php
@@ -15,10 +15,10 @@ interface PumpInterface
     /**
      * Sets flexible configuration values for this pump.
      * 
-     * @param array|null $data The configuration array.
+     * @param array $config The configuration array.
      * @return void
      */
-    public function configure(?array $config = null): void;
+    public function configure(array $config = []): void;
 
     /**
      * Process the data to be pumped.

--- a/src/Library/Benzina/Pump/Trait/ProgressivePumpTrait.php
+++ b/src/Library/Benzina/Pump/Trait/ProgressivePumpTrait.php
@@ -60,7 +60,6 @@ trait ProgressivePumpTrait
     public function isPumped(array $pumpingRecord, array $pumpedBatch): bool
     {
         if (
-            $this->config !== null &&
             \array_key_exists('progress', $this->config) &&
             $this->config['progress'] === false
         ) {


### PR DESCRIPTION
There was a small bug caused by a mismatch between the declared variable $config and the named variable $data in the docblock for the configure method in PumpInterface.php. It was causing ugly deprecation notices in the command line tools.

That is now fixed as well as an update on the interface of the configure method which no longer accepts null as value and defaults to an empty array, saving the need to check child classes if the $configure property is null or array and just check for the key they need.