### PR TITLE
v3 invest to transactions migration

### DIFF
--- a/.env
+++ b/.env
@@ -35,3 +35,4 @@ CORS_ALLOW_ORIGIN='^https?://(localhost|127\.0\.0\.1)(:[0-9]+)?$'
 ###< nelmio/cors-bundle ###
 
 STRIPE_API_KEY=""
+STRIPE_WEBHOOK_SECRET=""

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -56,6 +56,7 @@ services:
     App\Library\Economy\Payment\StripeGateway:
         arguments:
             - '%env(STRIPE_API_KEY)%'
+            - '%env(STRIPE_WEBHOOK_SECRET)%'
 
     # add more service definitions when explicit configuration is needed
     # please note that last definitions always *replace* previous ones

--- a/src/Command/GatewaysSetupCommand.php
+++ b/src/Command/GatewaysSetupCommand.php
@@ -2,6 +2,7 @@
 
 namespace App\Command;
 
+use App\DependencyInjection\Compiler\GatewaysCompilerPass;
 use App\Library\Economy\Payment\GatewayLocator;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
@@ -29,7 +30,11 @@ class GatewaysSetupCommand extends Command
         $io = new SymfonyStyle($input, $output);
 
         try {
-            $this->gatewayLocator->compileGatewayNames();
+            $classes = $this->gatewayLocator->getClasses();
+            GatewaysCompilerPass::validateGatewayNames($classes);
+
+            $names = $this->gatewayLocator->getNames();
+            GatewaysCompilerPass::compileGatewayNames($names);
 
             $io->success(self::SUCCESS_MESSAGE);
 

--- a/src/Controller/GatewayController.php
+++ b/src/Controller/GatewayController.php
@@ -2,11 +2,8 @@
 
 namespace App\Controller;
 
-use ApiPlatform\Api\IriConverterInterface;
 use App\Library\Economy\Payment\GatewayLocator;
-use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
-use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
@@ -22,8 +19,6 @@ class GatewayController extends AbstractController
 
     public function __construct(
         private GatewayLocator $gatewayLocator,
-        private EntityManagerInterface $entityManager,
-        private IriConverterInterface $iriConverter
     ) {
     }
 
@@ -31,18 +26,13 @@ class GatewayController extends AbstractController
     public function handleRedirect(Request $request): Response
     {
         $gateway = $this->gatewayLocator->getGateway($request->query->get('gateway'));
-        $checkout = $gateway->handleRedirect($request);
-
-        $this->entityManager->persist($checkout);
-        $this->entityManager->flush();
-
-        // TO-DO: This should redirect the user to a GUI
-        return new RedirectResponse($this->iriConverter->getIriFromResource($checkout));
+        return $gateway->handleRedirect($request);
     }
 
     #[Route('/gateway_webhooks', name: self::WEBHOOKS)]
     public function handleWebhook(Request $request): Response
     {
-        return new Response(500);
+        $gateway = $this->gatewayLocator->getGateway($request->query->get('gateway'));
+        return $gateway->handleWebhook($request);
     }
 }

--- a/src/Controller/GatewayController.php
+++ b/src/Controller/GatewayController.php
@@ -11,9 +11,15 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 
+/**
+ * The `GatewayController` exposes the handler routes for responding to network requests sent by external gateways.
+ */
 #[Route('/v4/controllers')]
 class GatewayController extends AbstractController
 {
+    public const REDIRECT = 'gateway_controller.redirect';
+    public const WEBHOOKS = 'gateway_controller.webhooks';
+
     public function __construct(
         private GatewayLocator $gatewayLocator,
         private EntityManagerInterface $entityManager,
@@ -21,7 +27,7 @@ class GatewayController extends AbstractController
     ) {
     }
 
-    #[Route('/gateway_redirect', name: 'gateway_redirect')]
+    #[Route('/gateway_redirects', name: self::REDIRECT)]
     public function handleRedirect(Request $request): Response
     {
         $gateway = $this->gatewayLocator->getGateway($request->query->get('gateway'));
@@ -32,5 +38,11 @@ class GatewayController extends AbstractController
 
         // TO-DO: This should redirect the user to a GUI
         return new RedirectResponse($this->iriConverter->getIriFromResource($checkout));
+    }
+
+    #[Route('/gateway_webhooks', name: self::WEBHOOKS)]
+    public function handleWebhook(Request $request): Response
+    {
+        return new Response(500);
     }
 }

--- a/src/Controller/GatewaysController.php
+++ b/src/Controller/GatewaysController.php
@@ -9,10 +9,10 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 
 /**
- * The `GatewayController` exposes the handler routes for responding to network requests sent by external gateways.
+ * The `GatewaysController` exposes the handler routes for responding to network requests sent by external gateways.
  */
 #[Route('/v4/controllers')]
-class GatewayController extends AbstractController
+class GatewaysController extends AbstractController
 {
     public const REDIRECT = 'gateway_controller.redirect';
     public const WEBHOOKS = 'gateway_controller.webhooks';
@@ -26,6 +26,7 @@ class GatewayController extends AbstractController
     public function handleRedirect(Request $request): Response
     {
         $gateway = $this->gatewayLocator->getGateway($request->query->get('gateway'));
+
         return $gateway->handleRedirect($request);
     }
 
@@ -33,6 +34,7 @@ class GatewayController extends AbstractController
     public function handleWebhook(Request $request): Response
     {
         $gateway = $this->gatewayLocator->getGateway($request->query->get('gateway'));
+
         return $gateway->handleWebhook($request);
     }
 }

--- a/src/DependencyInjection/Compiler/GatewayPass.php
+++ b/src/DependencyInjection/Compiler/GatewayPass.php
@@ -8,12 +8,138 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 class GatewayPass implements CompilerPassInterface
 {
+    public const GATEWAYS_DIR = 'gateways';
+    public const GATEWAY_NAMES_LOCK = 'gateway_names_compiled.lock';
+
+    public static function getGatewayCompileDir(): string
+    {
+        return sprintf(
+            '%s%svar%s%s',
+            \dirname(__DIR__, 3),
+            DIRECTORY_SEPARATOR,
+            DIRECTORY_SEPARATOR,
+            self::GATEWAYS_DIR,
+        );
+    }
+
+    public static function getGatewayNamesLockFile(): string
+    {
+        return sprintf(
+            '%s%s%s',
+            self::getGatewayCompileDir(),
+            DIRECTORY_SEPARATOR,
+            self::GATEWAY_NAMES_LOCK
+        );
+    }
+
+    /**
+     * Generates a directory for the gateways in the project var dir.
+     */
+    public static function makeCompileDir()
+    {
+        $compileDir = self::getGatewayCompileDir();
+
+        if (!\is_dir($compileDir)) {
+            \mkdir($compileDir, 0777, true);
+        }
+    }
+
+    /**
+     * Stores the gateway names in disk.
+     * 
+     * @param array $names The names returned by the interfaces
+     */
+    public static function compileGatewayNames(array $names)
+    {
+        self::makeCompileDir();
+
+        \file_put_contents(
+            self::getGatewayNamesLockFile(),
+            implode(PHP_EOL, $names)
+        );
+    }
+
+    private function getGatewayClasses(string $kernelDir): array
+    {
+        $classes = [];
+
+        $namespacePieces = \array_slice(explode('\\', GatewayLocator::class), 0, -1);
+
+        $economyDir = join(DIRECTORY_SEPARATOR, [
+            $kernelDir,
+            'src',
+            ...\array_slice($namespacePieces, 1)
+        ]);
+
+        $economyDirPaths = \scandir($economyDir);
+        foreach ($economyDirPaths as $path) {
+            if ($path === "." || $path === "..") {
+                continue;
+            }
+
+            $className = \rtrim($path, '.php');
+            if (!\str_ends_with($className, 'Gateway')) {
+                continue;
+            }
+
+            $reflection = new \ReflectionClass(sprintf("%s\%s", join("\\", $namespacePieces), $className));
+            if ($reflection->isAbstract()) {
+                continue;
+            }
+
+            $classes[] = $reflection->getName();
+        }
+
+        return $classes;
+    }
+
+    /**
+     * @throws \Exception If there are two different Gateway classes with the same name
+     *
+     * @param array $gatewayClasses Fully-qualified Gateway class names
+     * @see GatewayInterface::getName()
+     */
+    private function validateGatewayNames(array $gatewayClasses)
+    {
+        $gatewaysValidated = [];
+        foreach ($gatewayClasses as $gatewayClass) {
+            $gatewayName = $gatewayClass::getName();
+
+            if (\array_key_exists($gatewayName, $gatewaysValidated)) {
+                $exceptionMessage = sprintf(
+                    "Duplicate Gateway name '%s' from class %s, name is already in use by class %s",
+                    $gatewayName,
+                    $gatewayClass,
+                    $gatewaysValidated[$gatewayName]
+                );
+
+                throw new \Exception($exceptionMessage);
+            }
+
+            $gatewaysValidated[$gatewayName] = $gatewayClass;
+        }
+    }
+
+    /**
+     * @param array $gatewayClasses Fully-qualified Gateway class names
+     * @return array The names returned by each interface
+     */
+    private function getGatewayNames(array $gatewayClasses): array
+    {
+        $names = [];
+        foreach ($gatewayClasses as $class) {
+            $names[] = $class::getName();
+        }
+
+        return $names;
+    }
+
     public function process(ContainerBuilder $container): void
     {
-        /** @var GatewayLocator */
-        $gatewayLocator = $container->get(GatewayLocator::class);
+        $gatewayClasses = $this->getGatewayClasses($container->getParameter('kernel.project_dir'));
+        $this->validateGatewayNames($gatewayClasses);
 
-        $gatewayLocator->validateGatewayNames();
-        $gatewayLocator->compileGatewayNames();
+        $gatewayNames = $this->getGatewayNames($gatewayClasses);
+        self::compileGatewayNames($gatewayNames);
     }
 }

--- a/src/DependencyInjection/Compiler/GatewaysCompilerPass.php
+++ b/src/DependencyInjection/Compiler/GatewaysCompilerPass.php
@@ -56,7 +56,7 @@ class GatewaysCompilerPass implements CompilerPassInterface
 
     /**
      * Stores the gateway names in disk.
-     * 
+     *
      * @param array $names The names returned by the interfaces
      */
     public static function compileGatewayNames(array $names)
@@ -73,12 +73,12 @@ class GatewaysCompilerPass implements CompilerPassInterface
         $economyDir = join(DIRECTORY_SEPARATOR, [
             $projectDir,
             'src',
-            ...\array_slice($namespacePieces, 1)
+            ...\array_slice($namespacePieces, 1),
         ]);
 
         $economyDirPaths = \scandir($economyDir);
         foreach ($economyDirPaths as $path) {
-            if ($path === "." || $path === "..") {
+            if ($path === '.' || $path === '..') {
                 continue;
             }
 
@@ -87,7 +87,7 @@ class GatewaysCompilerPass implements CompilerPassInterface
                 continue;
             }
 
-            $reflection = new \ReflectionClass(sprintf("%s\%s", join("\\", $namespacePieces), $className));
+            $reflection = new \ReflectionClass(sprintf("%s\%s", join('\\', $namespacePieces), $className));
             if ($reflection->isAbstract()) {
                 continue;
             }
@@ -99,9 +99,10 @@ class GatewaysCompilerPass implements CompilerPassInterface
     }
 
     /**
+     * @param array $gatewayClasses Fully-qualified Gateway class names
+     *
      * @throws \Exception If there are two different Gateway classes with the same name
      *
-     * @param array $gatewayClasses Fully-qualified Gateway class names
      * @see GatewayInterface::getName()
      */
     public static function validateGatewayNames(array $gatewayClasses)
@@ -127,6 +128,7 @@ class GatewaysCompilerPass implements CompilerPassInterface
 
     /**
      * @param array $gatewayClasses Fully-qualified Gateway class names
+     *
      * @return array The names returned by each interface
      */
     private function getGatewayNames(array $gatewayClasses): array

--- a/src/DependencyInjection/Compiler/GatewaysCompilerPass.php
+++ b/src/DependencyInjection/Compiler/GatewaysCompilerPass.php
@@ -6,7 +6,7 @@ use App\Library\Economy\Payment\GatewayLocator;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
-class GatewayPass implements CompilerPassInterface
+class GatewaysCompilerPass implements CompilerPassInterface
 {
     public const GATEWAYS_DIR = 'gateways';
     public const GATEWAY_NAMES_LOCK = 'gateway_names_compiled.lock';

--- a/src/Entity/Accounting.php
+++ b/src/Entity/Accounting.php
@@ -46,9 +46,11 @@ class Accounting
     #[ORM\OneToOne(mappedBy: 'accounting', cascade: ['persist', 'remove'])]
     private ?Tipjar $tipjar = null;
 
+    #[API\ApiProperty(readableLink: false)]
     #[ORM\OneToMany(mappedBy: 'origin', targetEntity: AccountingTransaction::class)]
     private Collection $transactionsIssued;
 
+    #[API\ApiProperty(readableLink: false)]
     #[ORM\OneToMany(mappedBy: 'target', targetEntity: AccountingTransaction::class)]
     private Collection $transactionsReceived;
 
@@ -165,6 +167,10 @@ class Accounting
         return $this;
     }
 
+    /**
+     * @return Collection<int, AccountingTransaction>
+     */
+    #[API\ApiProperty(readableLink: false)]
     public function getTransactions(): Collection
     {
         $transactions = [

--- a/src/Entity/AccountingTransaction.php
+++ b/src/Entity/AccountingTransaction.php
@@ -2,6 +2,7 @@
 
 namespace App\Entity;
 
+use ApiPlatform\Metadata as API;
 use App\Repository\AccountingTransactionRepository;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Validator\Constraints as Assert;
@@ -12,6 +13,7 @@ use Symfony\Component\Validator\Constraints as Assert;
  * When a Transaction targets an Accounting it means that the Accounting receives it, this will add to that Accounting.
  * When a Transaction originates from an Accounting the Accounting issues the Transaction and it will deduct from it.
  */
+#[API\ApiResource()]
 #[ORM\Entity(repositoryClass: AccountingTransactionRepository::class)]
 class AccountingTransaction
 {

--- a/src/Entity/GatewayCharge.php
+++ b/src/Entity/GatewayCharge.php
@@ -46,7 +46,7 @@ class GatewayCharge
     /**
      * The AccountingTransaction generated for this charge after the checkout with the Gateway.
      */
-    #[API\ApiProperty(writable: false)]
+    #[API\ApiProperty(writable: false, readableLink: false)]
     #[ORM\OneToOne(cascade: ['persist', 'remove'])]
     private ?AccountingTransaction $transaction = null;
 

--- a/src/Entity/GatewayCharge.php
+++ b/src/Entity/GatewayCharge.php
@@ -2,6 +2,7 @@
 
 namespace App\Entity;
 
+use ApiPlatform\Metadata as API;
 use App\Repository\GatewayChargeRepository;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Validator\Constraints as Assert;
@@ -42,6 +43,13 @@ class GatewayCharge
     #[ORM\JoinColumn(nullable: false)]
     private ?Accounting $target = null;
 
+    /**
+     * The AccountingTransaction generated for this charge after the checkout with the Gateway.
+     */
+    #[API\ApiProperty(writable: false)]
+    #[ORM\OneToOne(cascade: ['persist', 'remove'])]
+    private ?AccountingTransaction $transaction = null;
+
     public function getId(): ?int
     {
         return $this->id;
@@ -79,6 +87,18 @@ class GatewayCharge
     public function setTarget(?Accounting $target): static
     {
         $this->target = $target;
+
+        return $this;
+    }
+
+    public function getTransaction(): ?AccountingTransaction
+    {
+        return $this->transaction;
+    }
+
+    public function setTransaction(?AccountingTransaction $transaction): static
+    {
+        $this->transaction = $transaction;
 
         return $this;
     }

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -2,7 +2,7 @@
 
 namespace App;
 
-use App\DependencyInjection\Compiler\GatewayPass;
+use App\DependencyInjection\Compiler\GatewaysCompilerPass;
 use App\DependencyInjection\Compiler\VersionedResourcePass;
 use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
 use Symfony\Component\DependencyInjection\Compiler\PassConfig;
@@ -16,7 +16,7 @@ class Kernel extends BaseKernel
     protected function build(ContainerBuilder $container): void
     {
         $container->addCompilerPass(
-            new GatewayPass(),
+            new GatewaysCompilerPass(),
             PassConfig::TYPE_AFTER_REMOVING
         );
 

--- a/src/Library/Benzina/Pump/CheckoutsPump.php
+++ b/src/Library/Benzina/Pump/CheckoutsPump.php
@@ -3,6 +3,7 @@
 namespace App\Library\Benzina\Pump;
 
 use App\Entity\Accounting;
+use App\Entity\AccountingTransaction;
 use App\Entity\GatewayCharge;
 use App\Entity\GatewayChargeType;
 use App\Entity\GatewayCheckout;
@@ -143,6 +144,21 @@ class CheckoutsPump extends AbstractPump implements PumpInterface
 
             $this->entityManager->persist($charge);
             $checkout->addCharge($charge);
+
+            if ($checkout->getStatus() === GatewayCheckoutStatus::Charged) {
+                foreach ($checkout->getCharges() as $charge) {
+
+                    $transaction = new AccountingTransaction();
+                    $transaction->setMoney($charge->getMoney());
+                    $transaction->setOrigin($checkout->getOrigin());
+                    $transaction->setTarget($charge->getTarget());
+
+                    $charge->setTransaction($transaction);
+
+                    $this->entityManager->persist($transaction);
+                    $this->entityManager->persist($charge);
+                }
+            }
 
             $this->entityManager->persist($checkout);
         }

--- a/src/Library/Benzina/Pump/CheckoutsPump.php
+++ b/src/Library/Benzina/Pump/CheckoutsPump.php
@@ -91,7 +91,7 @@ class CheckoutsPump extends AbstractPump implements PumpInterface
         $pumped = $this->getPumped(GatewayCheckout::class, $data, ['migratedReference' => 'id']);
 
         foreach ($data as $key => $record) {
-            if ($this->isPumped($record, $pumped)) {
+            if ($this->isPumped($record, $pumped, ['migratedReference' => 'id'])) {
                 continue;
             }
 

--- a/src/Library/Benzina/Pump/CheckoutsPump.php
+++ b/src/Library/Benzina/Pump/CheckoutsPump.php
@@ -147,7 +147,6 @@ class CheckoutsPump extends AbstractPump implements PumpInterface
 
             if ($checkout->getStatus() === GatewayCheckoutStatus::Charged) {
                 foreach ($checkout->getCharges() as $charge) {
-
                     $transaction = new AccountingTransaction();
                     $transaction->setMoney($charge->getMoney());
                     $transaction->setOrigin($checkout->getOrigin());

--- a/src/Library/Benzina/Pump/ProjectsPump.php
+++ b/src/Library/Benzina/Pump/ProjectsPump.php
@@ -115,7 +115,7 @@ class ProjectsPump extends AbstractPump implements PumpInterface
         $owners = $this->getOwners($data);
 
         foreach ($data as $key => $record) {
-            $isPumped = $this->isPumped($record, $pumped);
+            $isPumped = $this->isPumped($record, $pumped, ['migratedReference' => 'id']);
 
             if ($isPumped) {
                 continue;

--- a/src/Library/Benzina/Pump/Trait/ProgressivePumpTrait.php
+++ b/src/Library/Benzina/Pump/Trait/ProgressivePumpTrait.php
@@ -58,9 +58,13 @@ trait ProgressivePumpTrait
      *
      * @param array $pumpingRecord The data record to be pumped
      * @param array $pumpedBatch   The pumped data batch
+     * @param array $matchCriteria An array with the matching criteria between the entity key and the data key
      */
-    public function isPumped(array $pumpingRecord, array $pumpedBatch): bool
-    {
+    public function isPumped(
+        array $pumpingRecord,
+        array $pumpedBatch,
+        array $matchCriteria
+    ): bool {
         if (
             \array_key_exists('progress', $this->config)
             && $this->config['progress'] === false
@@ -68,6 +72,31 @@ trait ProgressivePumpTrait
             return false;
         }
 
-        return \array_key_exists($pumpingRecord['id'], $pumpedBatch);
+        $entityKey = \array_keys($matchCriteria)[0];
+        $pumpingKey = $matchCriteria[$entityKey];
+
+        return \array_key_exists($pumpingRecord[$pumpingKey], $pumpedBatch);
+    }
+
+    /**
+     * Obtain the pumped record in a pumped data batch from a pumping data record.
+     *
+     * @param array $pumpingRecord The data record being pumped
+     * @param array $pumpedBatch   The pumped data batch
+     * @param array $matchCriteria An array with the matching criteria between the entity key and the data key
+     */
+    public function getPumpedRecord(
+        array $pumpingRecord,
+        array $pumpedBatch,
+        array $matchCriteria
+    ): mixed {
+        $entityKey = \array_keys($matchCriteria)[0];
+        $pumpingKey = $matchCriteria[$entityKey];
+
+        if ($this->isPumped($pumpingRecord, $pumpedBatch, $matchCriteria)) {
+            return $pumpedBatch[$pumpingRecord[$pumpingKey]];
+        }
+
+        return false;
     }
 }

--- a/src/Library/Benzina/Pump/UsersPump.php
+++ b/src/Library/Benzina/Pump/UsersPump.php
@@ -69,7 +69,7 @@ class UsersPump extends AbstractPump implements PumpInterface
         $pumped = $this->getPumped(User::class, $data, ['migratedReference' => 'id']);
 
         foreach ($data as $key => $record) {
-            if ($this->isPumped($record, $pumped)) {
+            if ($this->isPumped($record, $pumped, ['migratedReference' => 'id'])) {
                 continue;
             }
 

--- a/src/Library/Economy/Payment/GatewayInterface.php
+++ b/src/Library/Economy/Payment/GatewayInterface.php
@@ -18,8 +18,8 @@ use Symfony\Component\HttpFoundation\Response;
  * 5. `App\State\GatewayCheckoutProcessor` returns the response data to the client app
  * 6. The client app redirects the user to the payment with the gateway
  * 7. The gateway processes the payment and redirects the user back to v4
- * 8. `App\Controller\GatewayController` catches the redirection and calls the `handleRedirect` method of the respective interface
- * 9. `App\Controller\GatewayController` also catches webhook events sent by the gateway and calls the `handleWebhook` method 
+ * 8. `App\Controller\GatewaysController` catches the redirection and calls the `handleRedirect` method of the respective interface
+ * 9. `App\Controller\GatewaysController` also catches webhook events sent by the gateway and calls the `handleWebhook` method.
  */
 interface GatewayInterface
 {
@@ -32,6 +32,7 @@ interface GatewayInterface
      * Connects with the payment gateway and creates a checkout session so the gateway can process the payment.
      *
      * @param GatewayCheckout $checkout The GatewayCheckout with the data for the payment to be charged
+     *
      * @return GatewayCheckout The GatewayCheckout updated with the data given by the gateway
      */
     public function sendData(GatewayCheckout $checkout): GatewayCheckout;
@@ -40,19 +41,21 @@ interface GatewayInterface
      * When a user is redirected by the gateway we must handle the redirection
      * and then redirect the user back to a GUI.\
      * \
-     * IMPORTANT: Redirection shouldn't be the only source of truth for gateway flow completion. 
+     * IMPORTANT: Redirection shouldn't be the only source of truth for gateway flow completion.
      * Webhook handling is the preferred method.\
      * This should, ideally, only handle redirections of the user back to the desired web app.
      *
      * @param Request $request The HTTP Request object
+     *
      * @return Response A RedirectResponse object to where the user should be redirected
      */
     public function handleRedirect(Request $request): RedirectResponse;
 
     /**
      * When supported by the gateway, webhook events should be the preferred method to receive gateway flow updates.
-     * 
+     *
      * @param Request $request The HTTP Request object of the webhook event
+     *
      * @return Response A Response object to send back to the gateway
      */
     public function handleWebhook(Request $request): Response;

--- a/src/Library/Economy/Payment/GatewayInterface.php
+++ b/src/Library/Economy/Payment/GatewayInterface.php
@@ -3,8 +3,24 @@
 namespace App\Library\Economy\Payment;
 
 use App\Entity\GatewayCheckout;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 
+/**
+ * Gateway interfaces are in charge of connecting with payment gateways to send them the data in `GatewayCheckout` instances.\
+ * \
+ * The flow is:
+ * 1. A client app creates a `GatewayCheckout` record
+ * 2. `App\State\GatewayCheckoutProcessor` calls the `sendData` method of the respective interface for the new `GatewayCheckout`
+ * 3. The interface connects with the gateway and sends the data for the `GatewayCheckout`
+ * 4. The interface updates the `GatewayCheckout` with the checkout url and reference given by the gateway for the checkout session
+ * 5. `App\State\GatewayCheckoutProcessor` returns the response data to the client app
+ * 6. The client app redirects the user to the payment with the gateway
+ * 7. The gateway processes the payment and redirects the user back to v4
+ * 8. `App\Controller\GatewayController` catches the redirection and calls the `handleRedirect` method of the respective interface
+ * 9. `App\Controller\GatewayController` also catches webhook events sent by the gateway and calls the `handleWebhook` method 
+ */
 interface GatewayInterface
 {
     /**
@@ -13,16 +29,31 @@ interface GatewayInterface
     public static function getName(): string;
 
     /**
-     * Connects with the payment gateway and creates a checkout session to process payment.
+     * Connects with the payment gateway and creates a checkout session so the gateway can process the payment.
      *
-     * Gateways are trusted to have secured the funds in the GatewayCheckout.
+     * @param GatewayCheckout $checkout The GatewayCheckout with the data for the payment to be charged
+     * @return GatewayCheckout The GatewayCheckout updated with the data given by the gateway
      */
-    public function create(GatewayCheckout $checkout): GatewayCheckout;
+    public function sendData(GatewayCheckout $checkout): GatewayCheckout;
 
     /**
-     * Updates a GatewayCheckout after the payment gateway redirects the user.
+     * When a user is redirected by the gateway we must handle the redirection
+     * and then redirect the user back to a GUI.\
+     * \
+     * IMPORTANT: Redirection shouldn't be the only source of truth for gateway flow completion. 
+     * Webhook handling is the preferred method.\
+     * This should, ideally, only handle redirections of the user back to the desired web app.
      *
      * @param Request $request The HTTP Request object
+     * @return Response A RedirectResponse object to where the user should be redirected
      */
-    public function handleRedirect(Request $request): GatewayCheckout;
+    public function handleRedirect(Request $request): RedirectResponse;
+
+    /**
+     * When supported by the gateway, webhook events should be the preferred method to receive gateway flow updates.
+     * 
+     * @param Request $request The HTTP Request object of the webhook event
+     * @return Response A Response object to send back to the gateway
+     */
+    public function handleWebhook(Request $request): Response;
 }

--- a/src/Library/Economy/Payment/GatewayLocator.php
+++ b/src/Library/Economy/Payment/GatewayLocator.php
@@ -2,13 +2,11 @@
 
 namespace App\Library\Economy\Payment;
 
+use App\DependencyInjection\Compiler\GatewaysCompilerPass;
 use App\Entity\GatewayCheckout;
 
 class GatewayLocator
 {
-    public const GATEWAYS_DIR = 'gateways';
-    public const GATEWAY_NAMES_LOCK = 'gateway_names_compiled.lock';
-
     /** @var GatewayInterface[] */
     private array $gatewaysByName = [];
 
@@ -21,85 +19,23 @@ class GatewayLocator
             $this->gatewaysByClass[$gateway::class] = $gateway;
         }
 
+        GatewaysCompilerPass::validateGatewayNames($this->gatewaysByClass);
+
         foreach ($this->gatewaysByClass as $class => $gateway) {
             $this->gatewaysByName[$gateway::getName()] = $gateway;
         }
     }
 
     /**
-     * @throws \Exception If there are two different Gateway classes with the same name
-     *
-     * @see GatewayInterface::getName()
+     * @return array<string> List of the fully-qualified class names of the available interfaces
      */
-    public function validateGatewayNames()
+    public function getClasses(): array
     {
-        $gatewaysValidated = [];
-        foreach ($this->gatewaysByClass as $class => $gateway) {
-            $gatewayName = $gateway::getName();
-
-            if (\array_key_exists($gatewayName, $gatewaysValidated)) {
-                $exceptionMessage = sprintf(
-                    "Duplicate Gateway name '%s' from class %s, name is already in use by class %s",
-                    $gatewayName,
-                    $gateway::class,
-                    $gatewaysValidated[$gatewayName]
-                );
-
-                throw new \Exception($exceptionMessage);
-            }
-
-            $gatewaysValidated[$gatewayName] = $class;
-        }
-    }
-
-    private static function getGatewayCompileDir(): string
-    {
-        return sprintf(
-            '%s%svar%s%s',
-            \dirname(__DIR__, 4),
-            DIRECTORY_SEPARATOR,
-            DIRECTORY_SEPARATOR,
-            self::GATEWAYS_DIR,
-        );
-    }
-
-    private static function getGatewayNamesLockFile(): string
-    {
-        return sprintf(
-            '%s%s%s',
-            self::getGatewayCompileDir(),
-            DIRECTORY_SEPARATOR,
-            self::GATEWAY_NAMES_LOCK
-        );
+        return \array_keys($this->gatewaysByClass);
     }
 
     /**
-     * Generates a directory for the gateways in the 'bundles' dir.
-     */
-    public function makeCompileDir()
-    {
-        $CompileDir = self::getGatewayCompileDir();
-
-        if (!\is_dir($CompileDir)) {
-            \mkdir($CompileDir, 0777, true);
-        }
-    }
-
-    /**
-     * Stores the available gateway names in disk.
-     */
-    public function compileGatewayNames()
-    {
-        $this->makeCompileDir();
-
-        \file_put_contents(
-            self::getGatewayNamesLockFile(),
-            implode(PHP_EOL, $this->getNames())
-        );
-    }
-
-    /**
-     * @return array<string> List of the available Gateway names
+     * @return array<string> List of names of the available interfaces
      */
     public function getNames(): array
     {
@@ -109,11 +45,11 @@ class GatewayLocator
     /**
      * @return array<string> List of the available Gateway names
      *
-     * @see compileGatewayNames()
+     * @see GatewaysCompilerPass::compileGatewayNames()
      */
     public static function getNamesStatic(): array
     {
-        return explode(PHP_EOL, \file_get_contents(self::getGatewayNamesLockFile()));
+        return explode(PHP_EOL, \file_get_contents(GatewaysCompilerPass::getLockFile()));
     }
 
     /**

--- a/src/Library/Economy/Payment/StripeGateway.php
+++ b/src/Library/Economy/Payment/StripeGateway.php
@@ -3,7 +3,7 @@
 namespace App\Library\Economy\Payment;
 
 use ApiPlatform\Api\IriConverterInterface;
-use App\Controller\GatewayController;
+use App\Controller\GatewaysController;
 use App\Entity\AccountingTransaction;
 use App\Entity\GatewayChargeType;
 use App\Entity\GatewayCheckout;
@@ -44,7 +44,7 @@ class StripeGateway implements GatewayInterface
     public function sendData(GatewayCheckout $checkout): GatewayCheckout
     {
         $successUrl = $this->router->generate(
-            GatewayController::REDIRECT,
+            GatewaysController::REDIRECT,
             [
                 'type' => self::RESPONSE_TYPE_SUCCESS,
                 'gateway' => $this->getName(),
@@ -129,7 +129,7 @@ class StripeGateway implements GatewayInterface
         switch ($webhook->type) {
             default:
                 return new JsonResponse([
-                    'error' => sprintf("The event '%s' is not supported", $webhook->type)
+                    'error' => sprintf("The event '%s' is not supported", $webhook->type),
                 ], Response::HTTP_BAD_REQUEST);
                 break;
         }

--- a/src/State/GatewayCheckoutProcessor.php
+++ b/src/State/GatewayCheckoutProcessor.php
@@ -26,7 +26,7 @@ class GatewayCheckoutProcessor implements ProcessorInterface
         $this->entityManager->persist($data);
         $this->entityManager->flush();
 
-        $checkout = $gateway->create($data);
+        $checkout = $gateway->sendData($data);
 
         $this->entityManager->persist($checkout);
         $this->entityManager->flush();


### PR DESCRIPTION
This PR is the meeting point of https://github.com/GoteoFoundation/v4/pull/15 and https://github.com/GoteoFoundation/v4/pull/6.

Previously these two key features were added separately:
1. Gateways.
With a common interface `App\Library\Economy\Payment\GatewayInterface` to add the concrete payment solutions and two entities: `App\Entity\GatewayCheckout` to store checkout sessions with any GatewayInterface, and `App\Entity\GatewayCharge` to represent different economic charges (which are transactions to-be) to the user performing the checkout session.
2. Accountings.
With the main entity `App\Entity\Accounting` made to abstract away the economic capabilities of entities that we desire to be both or either issuers and/or recipients of `App\Entity\AccountingTransaction` entities (a money amount moving from origin to target Accountings).

In this PR the `App\Library\Economy\Payment\StripeGateway` class ties both features with a gateway solution that can receive Gateway* entities and transform them into Accounting* byproducts once it verifies that the payment of a checkout session has been performed.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206763820785028