### PR TITLE
[fix] Timestamps usage

### DIFF
--- a/src/Entity/Trait/TimestampableCreationEntity.php
+++ b/src/Entity/Trait/TimestampableCreationEntity.php
@@ -17,27 +17,27 @@ trait TimestampableCreationEntity
     #[API\ApiProperty(writable: false)]
     #[Gedmo\Timestampable(on: 'create')]
     #[ORM\Column(type: Types::DATETIME_MUTABLE)]
-    protected $createdAt;
+    protected $dateCreated;
 
     /**
-     * Sets createdAt.
+     * Sets dateCreated.
      *
      * @return $this
      */
-    public function setCreatedAt(\DateTime $createdAt)
+    public function setDateCreated(\DateTime $dateCreated)
     {
-        $this->createdAt = $createdAt;
+        $this->dateCreated = $dateCreated;
 
         return $this;
     }
 
     /**
-     * Returns createdAt.
+     * Returns dateCreated.
      *
      * @return \DateTime|null
      */
-    public function getCreatedAt()
+    public function getDateCreated()
     {
-        return $this->createdAt;
+        return $this->dateCreated;
     }
 }

--- a/src/Entity/Trait/TimestampableUpdationEntity.php
+++ b/src/Entity/Trait/TimestampableUpdationEntity.php
@@ -17,27 +17,27 @@ trait TimestampableUpdationEntity
     #[API\ApiProperty(writable: false)]
     #[Gedmo\Timestampable(on: 'update')]
     #[ORM\Column(type: Types::DATETIME_MUTABLE)]
-    protected $updatedAt;
+    protected $dateUpdated;
 
     /**
-     * Sets updatedAt.
+     * Sets dateUpdated.
      *
      * @return $this
      */
-    public function setUpdatedAt(\DateTime $updatedAt)
+    public function setDateUpdated(\DateTime $dateUpdated)
     {
-        $this->updatedAt = $updatedAt;
+        $this->dateUpdated = $dateUpdated;
 
         return $this;
     }
 
     /**
-     * Returns updatedAt.
+     * Returns dateUpdated.
      *
      * @return \DateTime|null
      */
-    public function getUpdatedAt()
+    public function getDateUpdated()
     {
-        return $this->updatedAt;
+        return $this->dateUpdated;
     }
 }

--- a/src/Library/Benzina/Pump/CheckoutsPump.php
+++ b/src/Library/Benzina/Pump/CheckoutsPump.php
@@ -124,8 +124,8 @@ class CheckoutsPump extends AbstractPump implements PumpInterface
                 'transaction' => $record['transaction'],
                 'preapproval' => $record['preapproval'],
             ]);
-            $checkout->setCreatedAt(new \DateTime($record['invested']));
-            $checkout->setUpdatedAt(new \DateTime());
+
+            $checkout->setDateCreated(new \DateTime($record['invested']));
 
             $charge = new GatewayCharge();
             $charge->setType($this->getChargeType($record));

--- a/src/Library/Benzina/Pump/ProjectsPump.php
+++ b/src/Library/Benzina/Pump/ProjectsPump.php
@@ -135,8 +135,7 @@ class ProjectsPump extends AbstractPump implements PumpInterface
             $project->setStatus($this->getProjectStatus($record['status']));
             $project->setMigrated(true);
             $project->setMigratedReference($record['id']);
-            $project->setCreatedAt(new \DateTime($record['created']));
-            $project->setUpdatedAt(new \DateTime());
+            $project->setDateCreated(new \DateTime($record['created']));
 
             $accounting = $this->getAccounting($record);
             $accounting->setProject($project);

--- a/src/Library/Benzina/Pump/Trait/ProgressivePumpTrait.php
+++ b/src/Library/Benzina/Pump/Trait/ProgressivePumpTrait.php
@@ -66,8 +66,9 @@ trait ProgressivePumpTrait
         array $matchCriteria
     ): bool {
         if (
-            \array_key_exists('progress', $this->config)
+            isset($this->config)
             && $this->config['progress'] === false
+            && \array_key_exists('progress', $this->config)
         ) {
             return false;
         }

--- a/src/Library/Benzina/Pump/UsersPump.php
+++ b/src/Library/Benzina/Pump/UsersPump.php
@@ -78,9 +78,9 @@ class UsersPump extends AbstractPump implements PumpInterface
             $user->setUsername($this->getUsername($record));
             $user->setPassword($record['password'] ?? '');
             $user->setEmail($record['email']);
+            $user->setEmailConfirmed(false);
             $user->setName($record['name']);
             $user->setActive(false);
-            $user->setConfirmed(false);
             $user->setMigrated(true);
             $user->setMigratedReference($record['id']);
 

--- a/src/Library/Benzina/Pump/UsersPump.php
+++ b/src/Library/Benzina/Pump/UsersPump.php
@@ -13,7 +13,7 @@ class UsersPump extends AbstractPump implements PumpInterface
     use ArrayPumpTrait;
     use ProgressivePumpTrait;
 
-    private const USER_KEYS = [
+    public const USER_KEYS = [
         'id',
         'name',
         'location',
@@ -57,7 +57,7 @@ class UsersPump extends AbstractPump implements PumpInterface
 
     public function supports(mixed $data): bool
     {
-        if (!\is_array($data) || !\array_key_exists(0, $data)) {
+        if (!\is_array($data) || !\is_array($data[0])) {
             return false;
         }
 

--- a/tests/Library/Benzina/Pump/UsersPumpTest.php
+++ b/tests/Library/Benzina/Pump/UsersPumpTest.php
@@ -105,9 +105,9 @@ class UsersPumpTest extends KernelTestCase
         $user = $usersPostPumping[0];
 
         $this->assertEquals($testUser['email'], $user->getEmail());
-        $this->assertNotEquals($testUser['confirmed'], $user->getEmailConfirmed());
+        $this->assertNotEquals($testUser['confirmed'], $user->isEmailConfirmed());
 
-        $this->assertTrue($user->getMigrated());
+        $this->assertTrue($user->isMigrated());
         $this->assertEquals($testUser['id'], $user->getMigratedReference());
     }
 }

--- a/tests/Library/Benzina/Pump/UsersPumpTest.php
+++ b/tests/Library/Benzina/Pump/UsersPumpTest.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace App\Tests\Library\Benzina\Pump;
+
+use App\Entity\User;
+use App\Library\Benzina\Benzina;
+use App\Library\Benzina\Pump\UsersPump;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+class UsersPumpTest extends KernelTestCase
+{
+    use ResetDatabase;
+
+    private UsersPump $pump;
+    private EntityManagerInterface $entityManager;
+
+    public function setUp(): void
+    {
+        self::bootKernel();
+
+        $this->pump = static::getContainer()->get(UsersPump::class);
+        $this->entityManager = static::getContainer()->get(EntityManagerInterface::class);
+    }
+
+    public function testAcceptsOnlyUserCollection()
+    {
+        $object = $this->pump->supports(new \ArrayObject([
+            ['id', 'username', 'password'], ['id', 'username', 'password']]
+        ));
+
+        $this->assertFalse($object);
+
+        $arrayWithMissingKeys = $this->pump->supports([
+            ['id', 'username', 'password'], ['id', 'username', 'password']
+        ]);
+
+        $this->assertFalse($arrayWithMissingKeys);
+
+        $singleItemWithAllKeys = $this->pump->supports(UsersPump::USER_KEYS);
+
+        $this->assertFalse($singleItemWithAllKeys);
+
+        $collectionWithAllKeys = $this->pump->supports([ UsersPump::USER_KEYS, UsersPump::USER_KEYS ]);
+
+        $this->assertFalse($collectionWithAllKeys);
+    }
+
+    public function testProcessesUserData()
+    {
+        $testUser = [
+            'id' => 'test-user-id',
+            'name' => 'Test User name',
+            'location' => '',
+            'email' => 'testemail@test.test',
+            'password' => 'testuserpassword',
+            'gender' => 'F',
+            'birthyear' => '2024',
+            'entity_type' => 0,
+            'legal_entity' => 0,
+            'origin_register' => NULL,
+            'about' => 'Test User description',
+            'keywords' => NULL,
+            'active' => true,
+            'avatar' => 'test-user-avatar.jpg',
+            'contribution' => NULL,
+            'twitter' => NULL,
+            'facebook' => NULL,
+            'instagram' => NULL,
+            'identica' => NULL,
+            'linkedin' => NULL,
+            'amount' => 25,
+            'num_patron' => 0,
+            'num_patron_active' => 0,
+            'worth' => 1,
+            'created' => '2024-00-00',
+            'modified' => '2024-00-00',
+            'token' => '007fac056211808madeuptoken',
+            'rememberme' => '',
+            'hide' => 0,
+            'confirmed' => 1,
+            'lang' => 'es',
+            'node' => 'goteo',
+            'num_invested' => NULL,
+            'num_owned' => NULL,
+        ];
+
+        $supports = $this->pump->supports([ $testUser ]);
+
+        $this->assertTrue($supports);
+
+        $usersPrePumping = $this->entityManager->getRepository(User::class)
+            ->findAll();
+
+        $this->assertCount(0, $usersPrePumping);
+
+        $this->pump->process([ $testUser ]);
+
+        $usersPostPumping = $this->entityManager->getRepository(User::class)
+            ->findAll();
+
+        $this->assertCount(1, $usersPostPumping);
+
+        $user = $usersPostPumping[0];
+
+        $this->assertEquals($testUser['email'], $user->getEmail());
+        $this->assertNotEquals($testUser['confirmed'], $user->getEmailConfirmed());
+
+        $this->assertTrue($user->getMigrated());
+        $this->assertEquals($testUser['id'], $user->getMigratedReference());
+    }
+}

--- a/tests/Library/Benzina/Pump/UsersPumpTest.php
+++ b/tests/Library/Benzina/Pump/UsersPumpTest.php
@@ -3,7 +3,6 @@
 namespace App\Tests\Library\Benzina\Pump;
 
 use App\Entity\User;
-use App\Library\Benzina\Benzina;
 use App\Library\Benzina\Pump\UsersPump;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
@@ -26,14 +25,15 @@ class UsersPumpTest extends KernelTestCase
 
     public function testAcceptsOnlyUserCollection()
     {
-        $object = $this->pump->supports(new \ArrayObject([
-            ['id', 'username', 'password'], ['id', 'username', 'password']]
+        $object = $this->pump->supports(new \ArrayObject(
+            [
+                ['id', 'username', 'password'], ['id', 'username', 'password']]
         ));
 
         $this->assertFalse($object);
 
         $arrayWithMissingKeys = $this->pump->supports([
-            ['id', 'username', 'password'], ['id', 'username', 'password']
+            ['id', 'username', 'password'], ['id', 'username', 'password'],
         ]);
 
         $this->assertFalse($arrayWithMissingKeys);
@@ -42,7 +42,7 @@ class UsersPumpTest extends KernelTestCase
 
         $this->assertFalse($singleItemWithAllKeys);
 
-        $collectionWithAllKeys = $this->pump->supports([ UsersPump::USER_KEYS, UsersPump::USER_KEYS ]);
+        $collectionWithAllKeys = $this->pump->supports([UsersPump::USER_KEYS, UsersPump::USER_KEYS]);
 
         $this->assertFalse($collectionWithAllKeys);
     }
@@ -59,17 +59,17 @@ class UsersPumpTest extends KernelTestCase
             'birthyear' => '2024',
             'entity_type' => 0,
             'legal_entity' => 0,
-            'origin_register' => NULL,
+            'origin_register' => null,
             'about' => 'Test User description',
-            'keywords' => NULL,
+            'keywords' => null,
             'active' => true,
             'avatar' => 'test-user-avatar.jpg',
-            'contribution' => NULL,
-            'twitter' => NULL,
-            'facebook' => NULL,
-            'instagram' => NULL,
-            'identica' => NULL,
-            'linkedin' => NULL,
+            'contribution' => null,
+            'twitter' => null,
+            'facebook' => null,
+            'instagram' => null,
+            'identica' => null,
+            'linkedin' => null,
             'amount' => 25,
             'num_patron' => 0,
             'num_patron_active' => 0,
@@ -82,11 +82,11 @@ class UsersPumpTest extends KernelTestCase
             'confirmed' => 1,
             'lang' => 'es',
             'node' => 'goteo',
-            'num_invested' => NULL,
-            'num_owned' => NULL,
+            'num_invested' => null,
+            'num_owned' => null,
         ];
 
-        $supports = $this->pump->supports([ $testUser ]);
+        $supports = $this->pump->supports([$testUser]);
 
         $this->assertTrue($supports);
 
@@ -95,7 +95,7 @@ class UsersPumpTest extends KernelTestCase
 
         $this->assertCount(0, $usersPrePumping);
 
-        $this->pump->process([ $testUser ]);
+        $this->pump->process([$testUser]);
 
         $usersPostPumping = $this->entityManager->getRepository(User::class)
             ->findAll();


### PR DESCRIPTION
Normalized timestamp naming to start with `date` to make timestamp properties tidy, conciser and self-descriptive.

Added test for UsersPump too. 