### PR TITLE
[fix] XDebug profiling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,7 @@
 /.php-cs-fixer.php
 /.php-cs-fixer.cache
 ###< friendsofphp/php-cs-fixer ###
+
+###> XDebug ###
+/cachegrind*
+###< XDebug ###

--- a/docker/php/conf.d/xdebug.dev.ini
+++ b/docker/php/conf.d/xdebug.dev.ini
@@ -4,3 +4,4 @@ xdebug.client_host=host.docker.internal
 xdebug.client_port=9003
 xdebug.discover_client_host=0
 xdebug.start_with_request=trigger
+xdebug.output_dir=/app


### PR DESCRIPTION
We have XDebug enabled for development purposes, specially [profiling](https://xdebug.org/docs/profiler).

This PR makes it easier to retrieve the cachegrind profiling output by storing it in the app root dir, similar to other tools that output to the app root dir like PHPUnit or PHP CS Fixer result cache.

To generate a profiling cachegrind output you can add a `XDEBUG_TRIGGER` parameter on your requests.