### PR TITLE
[feat] Wallet checkout

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -9,6 +9,7 @@ return (new PhpCsFixer\Config())
         '@Symfony' => true,
         'method_argument_space' => ['on_multiline' => 'ensure_fully_multiline'],
         'function_declaration' => ['closure_fn_spacing' => 'none'],
+        'single_line_throw' => false,
         'single_line_empty_body' => true,
         'yoda_style' => [
             'equal' => false,

--- a/src/ApiResource/Accounting/Accounting.php
+++ b/src/ApiResource/Accounting/Accounting.php
@@ -18,7 +18,6 @@ use App\State\Accounting\AccountingStateProvider;
  * perform corroboration of funds and store the Transactions into the system.
  */
 #[API\ApiResource(
-    shortName: 'Accounting',
     stateOptions: new Options(entityClass: Entity\Accounting::class),
     provider: AccountingStateProvider::class,
     processor: AccountingStateProcessor::class,

--- a/src/ApiResource/Accounting/Accounting.php
+++ b/src/ApiResource/Accounting/Accounting.php
@@ -6,6 +6,7 @@ use ApiPlatform\Doctrine\Orm\State\Options;
 use ApiPlatform\Metadata as API;
 use App\Entity\Accounting as Entity;
 use App\Entity\Interface\AccountingOwnerInterface;
+use App\Entity\Money;
 use App\State\Accounting\AccountingStateProcessor;
 use App\State\Accounting\AccountingStateProvider;
 
@@ -32,4 +33,6 @@ class Accounting
     public ?string $currency = null;
 
     public ?AccountingOwnerInterface $owner = null;
+
+    public ?Money $balance = null;
 }

--- a/src/ApiResource/Gateway/Checkout.php
+++ b/src/ApiResource/Gateway/Checkout.php
@@ -10,6 +10,7 @@ use App\Gateway\CheckoutStatus;
 use App\Gateway\Link;
 use App\Gateway\Tracking;
 use App\State\Gateway\CheckoutStateProcessor;
+use App\State\Gateway\CheckoutStateProvider;
 use Symfony\Component\Validator\Constraints as Assert;
 
 /**
@@ -18,7 +19,8 @@ use Symfony\Component\Validator\Constraints as Assert;
 #[API\ApiResource(
     shortName: 'GatewayCheckout',
     stateOptions: new Options(entityClass: Entity\Checkout::class),
-    processor: CheckoutStateProcessor::class
+    provider: CheckoutStateProvider::class,
+    processor: CheckoutStateProcessor::class,
 )]
 #[API\GetCollection()]
 #[API\Post()]

--- a/src/ApiResource/Gateway/Gateway.php
+++ b/src/ApiResource/Gateway/Gateway.php
@@ -12,7 +12,7 @@ use App\State\Gateway\GatewayStateProvider;
  * These implementations make use of external or internal services to gather the funds that are inside a Transaction,
  * perform corroboration of funds and store the Transactions into the system.
  */
-#[API\ApiResource(shortName: 'Gateway')]
+#[API\ApiResource()]
 #[API\GetCollection(provider: GatewayStateProvider::class)]
 #[API\Get(provider: GatewayStateProvider::class)]
 class Gateway

--- a/src/Controller/GatewaysController.php
+++ b/src/Controller/GatewaysController.php
@@ -24,7 +24,7 @@ class GatewaysController extends AbstractController
     #[Route('/gateway_redirects', name: self::REDIRECT)]
     public function handleRedirect(Request $request): Response
     {
-        $gateway = $this->gatewayLocator->getGateway($request->query->get('gateway'));
+        $gateway = $this->gatewayLocator->get($request->query->get('gateway'));
 
         return $gateway->handleRedirect($request);
     }
@@ -32,7 +32,7 @@ class GatewaysController extends AbstractController
     #[Route('/gateway_webhooks', name: self::WEBHOOKS)]
     public function handleWebhook(Request $request): Response
     {
-        $gateway = $this->gatewayLocator->getGateway($request->query->get('gateway'));
+        $gateway = $this->gatewayLocator->get($request->query->get('gateway'));
 
         return $gateway->handleWebhook($request);
     }

--- a/src/Entity/Accounting/Accounting.php
+++ b/src/Entity/Accounting/Accounting.php
@@ -69,7 +69,7 @@ class Accounting
         return $this;
     }
 
-    public function getOwner(): AccountingOwnerInterface
+    public function getOwner(): ?AccountingOwnerInterface
     {
         $owner = $this->owner;
 

--- a/src/Entity/Gateway/Checkout.php
+++ b/src/Entity/Gateway/Checkout.php
@@ -68,7 +68,7 @@ class Checkout
      */
     #[Assert\NotBlank()]
     #[ORM\Column(length: 255)]
-    private ?string $gateway = null;
+    private ?string $gatewayName = null;
 
     /**
      * A list of URLs provided by the Gateway for this checkout.\
@@ -168,14 +168,14 @@ class Checkout
         return $this;
     }
 
-    public function getGateway(): ?string
+    public function getGatewayName(): ?string
     {
-        return $this->gateway;
+        return $this->gatewayName;
     }
 
-    public function setGateway(string $gateway): static
+    public function setGatewayName(string $gatewayName): static
     {
-        $this->gateway = $gateway;
+        $this->gatewayName = $gatewayName;
 
         return $this;
     }

--- a/src/Entity/WalletFinancement.php
+++ b/src/Entity/WalletFinancement.php
@@ -25,7 +25,7 @@ class WalletFinancement
     /**
      * An incoming Statement that originally saved the money in this Financement.
      */
-    #[ORM\ManyToOne(inversedBy: 'financesto')]
+    #[ORM\ManyToOne(inversedBy: 'financesTo')]
     #[ORM\JoinColumn(nullable: false)]
     private ?WalletStatement $origin = null;
 

--- a/src/Entity/WalletStatement.php
+++ b/src/Entity/WalletStatement.php
@@ -2,7 +2,6 @@
 
 namespace App\Entity;
 
-use ApiPlatform\Metadata as API;
 use App\Entity\Accounting\Transaction;
 use App\Gateway\Wallet\StatementDirection;
 use App\Repository\WalletStatementRepository;
@@ -18,7 +17,6 @@ use Doctrine\ORM\Mapping as ORM;
  * a. Targets an User's Accounting, for which an incoming Statement will be created and which will hold the money until it is spent.\
  * b. Originates from an User's Accounting via the Wallet Gateway, which will create an outgoing Statement with money financed from previous incoming statements.
  */
-#[API\ApiResource()]
 #[ORM\Entity(repositoryClass: WalletStatementRepository::class)]
 class WalletStatement
 {

--- a/src/Entity/WalletStatement.php
+++ b/src/Entity/WalletStatement.php
@@ -27,7 +27,7 @@ class WalletStatement
     #[ORM\Column]
     private ?int $id = null;
 
-    #[ORM\OneToOne(cascade: ['persist', 'remove'])]
+    #[ORM\OneToOne(cascade: ['persist'])]
     #[ORM\JoinColumn(nullable: false)]
     private ?Transaction $transaction = null;
 

--- a/src/EventListener/WalletTransactionsListener.php
+++ b/src/EventListener/WalletTransactionsListener.php
@@ -21,7 +21,7 @@ final class WalletTransactionsListener
     ) {}
 
     /**
-     * Generates a WalletStatement for User-received Transactions.
+     * Generates an income statement for User-received Transactions.
      */
     public function processTransaction(
         Transaction $transaction,
@@ -31,13 +31,13 @@ final class WalletTransactionsListener
             return;
         }
 
-        $statement = $this->wallet->save($transaction);
+        $income = $this->wallet->save($transaction);
 
-        if ($statement->getId() !== null) {
+        if ($income->getId() !== null) {
             return;
         }
 
-        $event->getObjectManager()->persist($statement);
+        $event->getObjectManager()->persist($income);
         $event->getObjectManager()->flush();
     }
 }

--- a/src/Gateway/Exception/DuplicateGatewayException.php
+++ b/src/Gateway/Exception/DuplicateGatewayException.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Gateway\Exception;
+
+class DuplicateGatewayException extends \Exception
+{
+    public const MESSAGE_DUPLICATE = 'Duplicate Gateway name \'%s\' from class %s, name is already in use by class %s';
+
+    public function __construct(
+        string $duplicateName,
+        string $duplicateClass,
+        string $existingClass,
+    ) {
+        parent::__construct(sprintf(
+            self::MESSAGE_DUPLICATE,
+            $duplicateName,
+            $duplicateClass,
+            $existingClass
+        ));
+    }
+}

--- a/src/Gateway/Exception/MissingGatewayException.php
+++ b/src/Gateway/Exception/MissingGatewayException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Gateway\Exception;
+
+class MissingGatewayException extends \Exception
+{
+    public const MESSAGE_NOT_FOUND = 'Could not match \'%s\' to the name of any available Gateway';
+
+    public function __construct(string $missingName)
+    {
+        parent::__construct(\sprintf(self::MESSAGE_NOT_FOUND, $missingName));
+    }
+}

--- a/src/Gateway/GatewayLocator.php
+++ b/src/Gateway/GatewayLocator.php
@@ -26,25 +26,9 @@ class GatewayLocator
     }
 
     /**
-     * @return array<string> List of the fully-qualified class names of the available interfaces
-     */
-    public function getClasses(): array
-    {
-        return \array_keys($this->gatewaysByClass);
-    }
-
-    /**
-     * @return array<string> List of names of the available interfaces
-     */
-    public function getNames(): array
-    {
-        return \array_keys($this->gatewaysByName);
-    }
-
-    /**
      * @return GatewayInterface[]
      */
-    public function getGateways(): array
+    public function getAll(): array
     {
         return $this->gatewaysByName;
     }
@@ -52,12 +36,12 @@ class GatewayLocator
     /**
      * @param string $name Name of the Gateway interface implementation
      *
-     * @throws \Exception When the $name does not match to that of an implemented Gateway
+     * @throws \Exception When the `$name` does not match to that of an implemented Gateway
      */
-    public function getGateway(string $name): GatewayInterface
+    public function get(string $name): GatewayInterface
     {
         if (!\array_key_exists($name, $this->gatewaysByName)) {
-            throw new \Exception("No such Gateway with the name $name");
+            throw new \Exception("Could not match '$name' to the name of any available Gateway implementation");
         }
 
         return $this->gatewaysByName[$name];
@@ -66,14 +50,14 @@ class GatewayLocator
     /**
      * @throws \Exception When the $checkout::gateway does not match to that of an implemented Gateway
      */
-    public function getGatewayOf(Checkout $checkout): GatewayInterface
+    public function getByCheckout(Checkout $checkout): GatewayInterface
     {
         $gateway = $checkout->getGatewayName();
         if (!$gateway) {
             throw new \Exception('The given GatewayCheckout does not specify a Gateway');
         }
 
-        return $this->getGateway($gateway);
+        return $this->get($gateway);
     }
 
     /**

--- a/src/Gateway/GatewayLocator.php
+++ b/src/Gateway/GatewayLocator.php
@@ -3,6 +3,7 @@
 namespace App\Gateway;
 
 use App\Entity\Gateway\Checkout;
+use App\Gateway\Exception\DuplicateGatewayException;
 
 class GatewayLocator
 {
@@ -26,7 +27,7 @@ class GatewayLocator
     }
 
     /**
-     * @return GatewayInterface[]
+     * @return <string, GatewayInterface>
      */
     public function getAll(): array
     {
@@ -41,7 +42,7 @@ class GatewayLocator
     public function get(string $name): GatewayInterface
     {
         if (!\array_key_exists($name, $this->gatewaysByName)) {
-            throw new \Exception("Could not match '$name' to the name of any available Gateway implementation");
+            throw new \Exception("Could not match '$name' to the name of any available Gateway");
         }
 
         return $this->gatewaysByName[$name];
@@ -54,7 +55,7 @@ class GatewayLocator
     {
         $gateway = $checkout->getGatewayName();
         if (!$gateway) {
-            throw new \Exception('The given GatewayCheckout does not specify a Gateway');
+            throw new \Exception('The given Gateway Checkout does not specify a Gateway');
         }
 
         return $this->get($gateway);
@@ -74,14 +75,11 @@ class GatewayLocator
             $gatewayName = $gatewayClass::getName();
 
             if (\array_key_exists($gatewayName, $gatewaysValidated)) {
-                $exceptionMessage = sprintf(
-                    "Duplicate Gateway name '%s' from class %s, name is already in use by class %s",
+                throw new DuplicateGatewayException(
                     $gatewayName,
-                    $gatewayClass,
-                    $gatewaysValidated[$gatewayName]
+                    $gatewayClass::class,
+                    $gatewaysValidated[$gatewayName]::class
                 );
-
-                throw new \Exception($exceptionMessage);
             }
 
             $gatewaysValidated[$gatewayName] = $gatewayClass;

--- a/src/Gateway/GatewayLocator.php
+++ b/src/Gateway/GatewayLocator.php
@@ -68,7 +68,7 @@ class GatewayLocator
      */
     public function getGatewayOf(Checkout $checkout): GatewayInterface
     {
-        $gateway = $checkout->getGateway();
+        $gateway = $checkout->getGatewayName();
         if (!$gateway) {
             throw new \Exception('The given GatewayCheckout does not specify a Gateway');
         }

--- a/src/Gateway/GatewayLocator.php
+++ b/src/Gateway/GatewayLocator.php
@@ -52,7 +52,7 @@ class GatewayLocator
     /**
      * @throws \Exception When the $checkout::gateway does not match to that of an implemented Gateway
      */
-    public function getByCheckout(Checkout $checkout): GatewayInterface
+    public function getForCheckout(Checkout $checkout): GatewayInterface
     {
         return $this->get($checkout->getGatewayName());
     }

--- a/src/Gateway/GatewayLocator.php
+++ b/src/Gateway/GatewayLocator.php
@@ -4,6 +4,7 @@ namespace App\Gateway;
 
 use App\Entity\Gateway\Checkout;
 use App\Gateway\Exception\DuplicateGatewayException;
+use App\Gateway\Exception\MissingGatewayException;
 
 class GatewayLocator
 {
@@ -42,7 +43,7 @@ class GatewayLocator
     public function get(string $name): GatewayInterface
     {
         if (!\array_key_exists($name, $this->gatewaysByName)) {
-            throw new \Exception("Could not match '$name' to the name of any available Gateway");
+            throw new MissingGatewayException($name);
         }
 
         return $this->gatewaysByName[$name];
@@ -53,12 +54,7 @@ class GatewayLocator
      */
     public function getByCheckout(Checkout $checkout): GatewayInterface
     {
-        $gateway = $checkout->getGatewayName();
-        if (!$gateway) {
-            throw new \Exception('The given Gateway Checkout does not specify a Gateway');
-        }
-
-        return $this->get($gateway);
+        return $this->get($checkout->getGatewayName());
     }
 
     /**

--- a/src/Gateway/Wallet/WalletGateway.php
+++ b/src/Gateway/Wallet/WalletGateway.php
@@ -52,17 +52,13 @@ class WalletGateway implements GatewayInterface
             $transaction->setOrigin($origin);
             $transaction->setTarget($charge->getTarget());
 
-            $outgoing = new WalletStatement();
-            $outgoing->setTransaction($transaction);
-            $outgoing->setDirection(StatementDirection::Outgoing);
+            $expenditure = $this->wallet->spend($transaction);
 
-            $outgoing = $this->wallet->spend($transaction);
+            $this->entityManager->persist($expenditure);
+            $this->entityManager->flush();
         }
 
         $checkout = $this->checkoutService->chargeCheckout($checkout);
-
-        $this->entityManager->persist($checkout);
-        $this->entityManager->flush();
 
         return $checkout;
     }

--- a/src/Gateway/Wallet/WalletGateway.php
+++ b/src/Gateway/Wallet/WalletGateway.php
@@ -5,7 +5,6 @@ namespace App\Gateway\Wallet;
 use App\Entity\Accounting\Transaction;
 use App\Entity\Gateway\Checkout;
 use App\Entity\Money;
-use App\Entity\WalletStatement;
 use App\Gateway\ChargeType;
 use App\Gateway\GatewayInterface;
 use App\Library\Economy\MoneyService;

--- a/src/Gateway/Wallet/WalletService.php
+++ b/src/Gateway/Wallet/WalletService.php
@@ -31,14 +31,10 @@ class WalletService
     public function getBalance(Accounting $accounting): Money
     {
         $total = Brick\Money::ofMinor(0, $accounting->getCurrency());
-        $statements = $this->getStatements($accounting);
+        $statements = $this->statementRepository->findByTarget($accounting);
 
         foreach ($statements as $statement) {
             $balance = $this->money->toBrick($statement->getBalance());
-
-            if (!$statement->hasDirection(StatementDirection::Incoming)) {
-                continue;
-            }
 
             $total = $total->plus($balance);
         }

--- a/src/Library/Benzina/Pump/CheckoutsPump.php
+++ b/src/Library/Benzina/Pump/CheckoutsPump.php
@@ -117,7 +117,7 @@ class CheckoutsPump extends AbstractPump implements PumpInterface
             $checkout = new Checkout();
             $checkout->setOrigin($user->getAccounting());
             $checkout->setStatus($this->getCheckoutStatus($record));
-            $checkout->setGateway($this->getCheckoutGateway($record));
+            $checkout->setGatewayName($this->getCheckoutGateway($record));
 
             foreach ($this->getCheckoutTrackings($record) as $tracking) {
                 $checkout->addTracking($tracking);

--- a/src/Mapping/Accounting/AccountingMapper.php
+++ b/src/Mapping/Accounting/AccountingMapper.php
@@ -4,7 +4,13 @@ namespace App\Mapping\Accounting;
 
 use App\ApiResource\Accounting as Resource;
 use App\Entity\Accounting as Entity;
+use App\Entity\Interface\AccountingOwnerInterface;
+use App\Entity\Money;
+use App\Entity\User;
+use App\Gateway\Wallet\WalletService;
+use App\Library\Economy\MoneyService;
 use App\Repository\Accounting\AccountingRepository;
+use App\Repository\Accounting\TransactionRepository;
 use Doctrine\ORM\EntityManagerInterface;
 
 class AccountingMapper
@@ -12,6 +18,9 @@ class AccountingMapper
     public function __construct(
         private EntityManagerInterface $entityManager,
         private AccountingRepository $accountingRepository,
+        private TransactionRepository $transactionRepository,
+        private WalletService $wallet,
+        private MoneyService $money,
     ) {}
 
     public function toResource(Entity\Accounting $entity): Resource\Accounting
@@ -22,6 +31,7 @@ class AccountingMapper
         $resource->id = $entity->getId();
         $resource->currency = $entity->getCurrency();
         $resource->owner = $owner;
+        $resource->balance = $this->getBalance($owner);
 
         return $resource;
     }
@@ -38,5 +48,29 @@ class AccountingMapper
         $entity->setOwner($resource->owner);
 
         return $entity;
+    }
+
+    private function getBalance(AccountingOwnerInterface $owner): Money
+    {
+        if ($owner instanceof User) {
+            return $this->wallet->getBalance($owner->getAccounting());
+        }
+
+        $accounting = $owner->getAccounting();
+
+        $balance = new Money(0, $accounting->getCurrency());
+        $transactions = $this->transactionRepository->findByAccounting($accounting);
+
+        foreach ($transactions as $transaction) {
+            if ($transaction->getTarget() === $accounting) {
+                $balance = $this->money->add($transaction->getMoney(), $balance);
+            }
+
+            if ($transaction->getOrigin() === $accounting) {
+                $balance = $this->money->substract($transaction->getMoney(), $balance);
+            }
+        }
+
+        return $balance;
     }
 }

--- a/src/Mapping/Gateway/CheckoutMapper.php
+++ b/src/Mapping/Gateway/CheckoutMapper.php
@@ -24,7 +24,7 @@ class CheckoutMapper
         $resource = new Resource\Checkout();
         $resource->id = $entity->getId();
 
-        $gateway = $this->gatewayLocator->getGateway($entity->getGateway());
+        $gateway = $this->gatewayLocator->getGatewayOf($entity);
         $resource->gateway = $this->gatewayMapper->toResource($gateway);
 
         $resource->origin = $this->accountingMapper->toResource($entity->getOrigin());
@@ -51,7 +51,7 @@ class CheckoutMapper
             $entity = $this->checkoutRepository->find($resource->id);
         }
 
-        $entity->setGateway($resource->gateway->name);
+        $entity->setGatewayName($resource->gateway->name);
         $entity->setOrigin($this->accountingMapper->toEntity($resource->origin));
 
         $charges = [];

--- a/src/Mapping/Gateway/CheckoutMapper.php
+++ b/src/Mapping/Gateway/CheckoutMapper.php
@@ -24,7 +24,7 @@ class CheckoutMapper
         $resource = new Resource\Checkout();
         $resource->id = $entity->getId();
 
-        $gateway = $this->gatewayLocator->getByCheckout($entity);
+        $gateway = $this->gatewayLocator->getForCheckout($entity);
         $resource->gateway = $this->gatewayMapper->toResource($gateway);
 
         $resource->origin = $this->accountingMapper->toResource($entity->getOrigin());

--- a/src/Mapping/Gateway/CheckoutMapper.php
+++ b/src/Mapping/Gateway/CheckoutMapper.php
@@ -24,7 +24,7 @@ class CheckoutMapper
         $resource = new Resource\Checkout();
         $resource->id = $entity->getId();
 
-        $gateway = $this->gatewayLocator->getGatewayOf($entity);
+        $gateway = $this->gatewayLocator->getByCheckout($entity);
         $resource->gateway = $this->gatewayMapper->toResource($gateway);
 
         $resource->origin = $this->accountingMapper->toResource($entity->getOrigin());

--- a/src/Repository/Accounting/TransactionRepository.php
+++ b/src/Repository/Accounting/TransactionRepository.php
@@ -2,6 +2,7 @@
 
 namespace App\Repository\Accounting;
 
+use App\Entity\Accounting\Accounting;
 use App\Entity\Accounting\Transaction;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
@@ -19,6 +20,49 @@ class TransactionRepository extends ServiceEntityRepository
     public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, Transaction::class);
+    }
+
+    /**
+     * @return Transaction[] Transactions originated from or targeting the Accounting
+     */
+    public function findByAccounting(Accounting $accounting): array
+    {
+        return $this->createQueryBuilder('t')
+            ->andWhere('t.origin = :val')
+            ->orWhere('t.target = :val')
+            ->setParameter('val', $accounting)
+            ->orderBy('t.id', 'ASC')
+            ->getQuery()
+            ->getResult()
+        ;
+    }
+
+    /**
+     * @return Transaction[] Transactions originated from the Accounting
+     */
+    public function findByOrigin(Accounting $origin): array
+    {
+        return $this->createQueryBuilder('t')
+            ->andWhere('t.origin = :val')
+            ->setParameter('val', $origin)
+            ->orderBy('t.id', 'ASC')
+            ->getQuery()
+            ->getResult()
+        ;
+    }
+
+    /**
+     * @return Transaction[] Transactions targetting the Accounting
+     */
+    public function findByTarget(Accounting $origin): array
+    {
+        return $this->createQueryBuilder('t')
+            ->andWhere('t.target = :val')
+            ->setParameter('val', $origin)
+            ->orderBy('t.id', 'ASC')
+            ->getQuery()
+            ->getResult()
+        ;
     }
 
     //    /**

--- a/src/Repository/WalletStatementRepository.php
+++ b/src/Repository/WalletStatementRepository.php
@@ -3,6 +3,7 @@
 namespace App\Repository;
 
 use App\Entity\Accounting\Accounting;
+use App\Entity\Accounting\Transaction;
 use App\Entity\WalletStatement;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\ORM\Query\Expr\Join;
@@ -61,6 +62,20 @@ class WalletStatementRepository extends ServiceEntityRepository
             ->orderBy('w.id', 'ASC')
             ->getQuery()
             ->getResult()
+        ;
+    }
+
+    public function findByTransaction(Transaction $transaction): ?WalletStatement
+    {
+        if ($transaction->getId() === null) {
+            return null;
+        }
+
+        return $this->createQueryBuilder('w')
+            ->andWhere('w.transaction = :val')
+            ->setParameter('val', $transaction)
+            ->getQuery()
+            ->getOneOrNullResult()
         ;
     }
 

--- a/src/Service/Gateway/CheckoutService.php
+++ b/src/Service/Gateway/CheckoutService.php
@@ -6,7 +6,7 @@ use App\Controller\GatewaysController;
 use App\Entity\Accounting\Transaction;
 use App\Entity\Gateway\Charge;
 use App\Entity\Gateway\Checkout;
-use App\Entity\Gateway\CheckoutStatus;
+use App\Gateway\CheckoutStatus;
 use Symfony\Component\Routing\RouterInterface;
 
 class CheckoutService

--- a/src/Service/Gateway/CheckoutService.php
+++ b/src/Service/Gateway/CheckoutService.php
@@ -32,7 +32,7 @@ class CheckoutService
             GatewaysController::REDIRECT,
             [
                 'type' => $type,
-                'gateway' => $checkout->getGateway(),
+                'gateway' => $checkout->getGatewayName(),
                 'checkoutId' => $checkout->getId(),
                 ...$parameters,
             ],

--- a/src/State/Gateway/CheckoutStateProcessor.php
+++ b/src/State/Gateway/CheckoutStateProcessor.php
@@ -29,7 +29,7 @@ class CheckoutStateProcessor implements ProcessorInterface
         $entity = $this->checkoutMapper->toEntity($data);
         $entity = $this->innerProcessor->process($entity, $operation, $uriVariables, $context);
 
-        $entity = $this->gatewayLocator->getGateway($data->gateway->name)->process($entity);
+        $entity = $this->gatewayLocator->get($data->gateway->name)->process($entity);
         $entity = $this->innerProcessor->process($entity, $operation, $uriVariables, $context);
 
         return $this->checkoutMapper->toResource($entity);

--- a/src/State/Gateway/CheckoutStateProvider.php
+++ b/src/State/Gateway/CheckoutStateProvider.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\State\Gateway;
+
+use ApiPlatform\Doctrine\Orm\State\CollectionProvider;
+use ApiPlatform\Doctrine\Orm\State\ItemProvider;
+use ApiPlatform\Metadata\CollectionOperationInterface;
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProviderInterface;
+use App\Mapping\Gateway\CheckoutMapper;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
+class CheckoutStateProvider implements ProviderInterface
+{
+    public function __construct(
+        private CheckoutMapper $checkoutMapper,
+        #[Autowire(service: CollectionProvider::class)]
+        private ProviderInterface $collectionProvider,
+        #[Autowire(service: ItemProvider::class)]
+        private ProviderInterface $itemProvider,
+    ) {}
+
+    public function provide(Operation $operation, array $uriVariables = [], array $context = []): object|array|null
+    {
+        if ($operation instanceof CollectionOperationInterface) {
+            $entities = $this->collectionProvider->provide($operation, $uriVariables, $context);
+
+            $resources = [];
+            foreach ($entities as $entity) {
+                $resources[] = $this->checkoutMapper->toResource($entity);
+            }
+
+            return $resources;
+        }
+
+        $entity = $this->itemProvider->provide($operation, $uriVariables, $context);
+
+        if ($entity === null) {
+            return null;
+        }
+
+        return $this->checkoutMapper->toResource($entity);
+    }
+}

--- a/src/State/Gateway/GatewayStateProvider.php
+++ b/src/State/Gateway/GatewayStateProvider.php
@@ -30,7 +30,7 @@ class GatewayStateProvider implements ProviderInterface
     private function getGateways(): array
     {
         $gateways = [];
-        foreach ($this->gateways->getGateways() as $gateway) {
+        foreach ($this->gateways->getAll() as $gateway) {
             $gateways[] = $this->gatewayMapper->toResource($gateway);
         }
 
@@ -40,7 +40,7 @@ class GatewayStateProvider implements ProviderInterface
     private function getGateway(string $name): Gateway
     {
         try {
-            $gateway = $this->gateways->getGateway($name);
+            $gateway = $this->gateways->get($name);
 
             return $this->gatewayMapper->toResource($gateway);
         } catch (\Exception $e) {

--- a/src/Validator/SupportedChargeTypesValidator.php
+++ b/src/Validator/SupportedChargeTypesValidator.php
@@ -15,7 +15,7 @@ class SupportedChargeTypesValidator extends ConstraintValidator
 
     /**
      * @param Collection<int, \App\Entity\Gateway\Charge> $value
-     * @param SupportedChargeTypes $constraint
+     * @param SupportedChargeTypes                        $constraint
      */
     public function validate(mixed $value, Constraint $constraint): void
     {

--- a/src/Validator/SupportedChargeTypesValidator.php
+++ b/src/Validator/SupportedChargeTypesValidator.php
@@ -27,7 +27,7 @@ class SupportedChargeTypesValidator extends ConstraintValidator
         $charges = $value;
 
         $checkout = $charges->toArray()[0]->getCheckout();
-        $gateway = $this->gatewayLocator->getGatewayOf($checkout);
+        $gateway = $this->gatewayLocator->getByCheckout($checkout);
 
         foreach ($charges as $charge) {
             if (!\in_array(

--- a/src/Validator/SupportedChargeTypesValidator.php
+++ b/src/Validator/SupportedChargeTypesValidator.php
@@ -13,6 +13,10 @@ class SupportedChargeTypesValidator extends ConstraintValidator
         private GatewayLocator $gatewayLocator,
     ) {}
 
+    /**
+     * @param Collection<int, \App\Entity\Gateway\Charge> $value
+     * @param SupportedChargeTypes $constraint
+     */
     public function validate(mixed $value, Constraint $constraint): void
     {
         if ($value === null || $value === '') {
@@ -23,17 +27,12 @@ class SupportedChargeTypesValidator extends ConstraintValidator
             return;
         }
 
-        /** @var Collection<int, \App\Entity\Gateway\Charge> */
-        $charges = $value;
+        $checkout = $value->toArray()[0]->getCheckout();
+        $gateway = $this->gatewayLocator->getForCheckout($checkout);
+        $supportedTypes = $gateway->getSupportedChargeTypes();
 
-        $checkout = $charges->toArray()[0]->getCheckout();
-        $gateway = $this->gatewayLocator->getByCheckout($checkout);
-
-        foreach ($charges as $charge) {
-            if (!\in_array(
-                $charge->getType(),
-                $gateway->getSupportedChargeTypes()
-            )) {
+        foreach ($value as $charge) {
+            if (!\in_array($charge->getType(), $supportedTypes)) {
                 $this->context->buildViolation($constraint->message)
                     ->setParameter('{{ value }}', $charge->getType()->value)
                     ->setParameter('{{ gateway }}', $gateway->getName())


### PR DESCRIPTION
This PR wraps up the work done in https://github.com/GoteoFoundation/v4/pull/30, which implements the mechanisms necessary for the Wallet to work, i.e: the Gateway itself. Here I finish the work by completing the Gateway implementation allowing for checkouts to be performed via the "wallet" Gateway.

The difference is similar to the two-piece work done in the other Gateway implementations like PayPal in https://github.com/GoteoFoundation/v4/pull/26, where there is a dedicated service class, in charge of performing the actual gateway operations (for PayPal this is communication with their API, for Wallet this is doing balance checks and financing money from previous income), and the gateway implementation class, in charge of processing the checkout data and gateway service usage.