### PR TITLE
[fix] Versioned Resources API

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,6 @@
         "phpstan/phpdoc-parser": "^1.24",
         "stof/doctrine-extensions-bundle": "^1.11",
         "stripe/stripe-php": "^15.0",
-        "subiabre/doctrine-snowflakes": "^2.0",
         "symfony/asset": "6.4.*",
         "symfony/cache": "6.4.*",
         "symfony/console": "6.4.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0d0e2940f9aaecab4ba3c50bc5822de6",
+    "content-hash": "12528cb2aa86e56aac757107d3c97554",
     "packages": [
         {
             "name": "api-platform/core",
@@ -2053,73 +2053,6 @@
             "time": "2024-10-07T22:30:27+00:00"
         },
         {
-            "name": "godruoyi/php-snowflake",
-            "version": "3.1.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/godruoyi/php-snowflake.git",
-                "reference": "cbf44765679bd1e58f1c2ec0263eb340dd0d6f47"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/godruoyi/php-snowflake/zipball/cbf44765679bd1e58f1c2ec0263eb340dd0d6f47",
-                "reference": "cbf44765679bd1e58f1c2ec0263eb340dd0d6f47",
-                "shasum": ""
-            },
-            "require": {
-                "php-64bit": ">=8.1"
-            },
-            "require-dev": {
-                "ext-redis": "*",
-                "ext-swoole": "*",
-                "illuminate/contracts": "^10.0 || ^11.0",
-                "laravel/pint": "^1.10",
-                "phpstan/phpstan": "^1.10",
-                "phpunit/phpunit": "^10",
-                "predis/predis": "^2.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Godruoyi\\Snowflake\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Godruoyi",
-                    "email": "g@godruoyi.com"
-                }
-            ],
-            "description": "An ID Generator for PHP based on Snowflake Algorithm (Twitter announced).",
-            "homepage": "https://github.com/godruoyi/php-snowflake",
-            "keywords": [
-                "Unique ID",
-                "laravel snowflake",
-                "order id",
-                "php snowflake",
-                "php sonyflake",
-                "php unique id",
-                "snowflake algorithm",
-                "sonyflake",
-                "unique order id"
-            ],
-            "support": {
-                "issues": "https://github.com/godruoyi/php-snowflake/issues",
-                "source": "https://github.com/godruoyi/php-snowflake/tree/3.1.0"
-            },
-            "funding": [
-                {
-                    "url": "https://images.godruoyi.com/wechat.png",
-                    "type": "custom"
-                }
-            ],
-            "time": "2024-04-08T07:08:02+00:00"
-        },
-        {
             "name": "monolog/monolog",
             "version": "3.7.0",
             "source": {
@@ -3229,50 +3162,6 @@
                 "source": "https://github.com/stripe/stripe-php/tree/v15.10.0"
             },
             "time": "2024-09-18T18:38:30+00:00"
-        },
-        {
-            "name": "subiabre/doctrine-snowflakes",
-            "version": "2.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/subiabre/doctrine-snowflakes.git",
-                "reference": "f179b7aba6f4d08d455b3369b0af4903693de489"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/subiabre/doctrine-snowflakes/zipball/f179b7aba6f4d08d455b3369b0af4903693de489",
-                "reference": "f179b7aba6f4d08d455b3369b0af4903693de489",
-                "shasum": ""
-            },
-            "require": {
-                "doctrine/orm": "^2.16",
-                "godruoyi/php-snowflake": "^3.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^10.4"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Subiabre\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Daniel Subiabre",
-                    "email": "subiabrewd@gmail.com"
-                }
-            ],
-            "description": "Custom id generator implementing snowflake algorithm",
-            "support": {
-                "issues": "https://github.com/subiabre/doctrine-snowflakes/issues",
-                "source": "https://github.com/subiabre/doctrine-snowflakes/tree/2.0"
-            },
-            "time": "2023-11-13T19:04:37+00:00"
         },
         {
             "name": "symfony/asset",

--- a/src/ApiResource/Accounting/Accounting.php
+++ b/src/ApiResource/Accounting/Accounting.php
@@ -4,8 +4,8 @@ namespace App\ApiResource\Accounting;
 
 use ApiPlatform\Doctrine\Orm\State\Options;
 use ApiPlatform\Metadata as API;
+use App\ApiResource\EmbeddedResource;
 use App\Entity\Accounting as Entity;
-use App\Entity\Interface\AccountingOwnerInterface;
 use App\Entity\Money;
 use App\State\Accounting\AccountingStateProcessor;
 use App\State\Accounting\AccountingStateProvider;
@@ -27,11 +27,11 @@ use App\State\Accounting\AccountingStateProvider;
 #[API\Patch(security: 'is_granted("ACCOUNTING_EDIT", object)')]
 class Accounting
 {
-    public ?int $id = null;
+    public int $id;
 
-    public ?string $currency = null;
+    public string $currency;
 
-    public ?AccountingOwnerInterface $owner = null;
+    public EmbeddedResource $owner;
 
-    public ?Money $balance = null;
+    public Money $balance;
 }

--- a/src/ApiResource/EmbeddedResource.php
+++ b/src/ApiResource/EmbeddedResource.php
@@ -16,8 +16,8 @@ class EmbeddedResource
 
     /**
      * Actual object data of the embedded resource.
-     * 
+     *
      * @var array<string, mixed>
      */
-    public object $resource;
+    public mixed $resource;
 }

--- a/src/ApiResource/EmbeddedResource.php
+++ b/src/ApiResource/EmbeddedResource.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\ApiResource;
+
+class EmbeddedResource
+{
+    /**
+     * ID of the embedded resource.
+     */
+    public int $id;
+
+    /**
+     * Path to the embedded resource.
+     */
+    public string $iri;
+
+    /**
+     * Actual object data of the embedded resource.
+     * 
+     * @var array<string, mixed>
+     */
+    public object $resource;
+}

--- a/src/ApiResource/Version.php
+++ b/src/ApiResource/Version.php
@@ -5,9 +5,7 @@ namespace App\ApiResource;
 use ApiPlatform\Metadata as API;
 use App\Filter\ResourceVersionResourceFilter;
 use App\Filter\ResourceVersionResourceIdFilter;
-use App\Service\ApiService;
 use App\State\ResourceVersionStateProvider;
-use Gedmo\Loggable\Entity\LogEntry;
 
 /**
  * Some resources are versioned. This means v4 keeps track of the changes performed in subsets of specific properties within these resources.\
@@ -21,64 +19,32 @@ use Gedmo\Loggable\Entity\LogEntry;
 #[API\Get(provider: ResourceVersionStateProvider::class)]
 class Version
 {
-    public function __construct(
-        private readonly LogEntry $log,
-        private readonly object $entity,
-    ) {}
+    public int $id;
 
     /**
-     * The ID of the version record.
+     * Version number for the resource object.
      */
-    public function getId(): ?int
-    {
-        return $this->log->getId();
-    }
+    public int $version;
 
     /**
-     * The ID of the version for this specific resource.
+     * The action-type that performed the version change.
      */
-    public function getVersion(): ?int
-    {
-        return $this->log->getVersion();
-    }
+    public string $action;
 
     /**
-     * The type of action that performed the recorded changes.
+     * The changes made by the action for this version.
+     *
+     * @return array<string, mixed>
      */
-    public function getAction(): ?string
-    {
-        return $this->log->getAction();
-    }
+    public array $changes;
 
     /**
-     * The type of the recorded resource.
+     * Reconstructed resource data for this version.
      */
-    public function getResource(): string
-    {
-        return ApiService::toResource($this->log->getObjectClass());
-    }
+    public EmbeddedResource $resource;
 
     /**
-     * The ID of the recorded resource.
+     * Version creation timestamp.
      */
-    public function getResourceId(): int
-    {
-        return $this->log->getObjectId();
-    }
-
-    /**
-     * The changed resource data, i.e the new values of the changed properties.
-     */
-    public function getResourceChanges()
-    {
-        return $this->log->getData();
-    }
-
-    /**
-     * The date at which this version was created.
-     */
-    public function getDateCreated(): ?\DateTimeInterface
-    {
-        return $this->log->getLoggedAt();
-    }
+    public \DateTimeInterface $dateCreated;
 }


### PR DESCRIPTION
We were lacking a descriptive way to shape polymorphic relationships in the API.

Main offender was in the `Version` API resource, which used to embed the full data of any versioned resource in a version resource without context of what the embed object it and what to expect for it. This PRs adds a middle `EmbeddedResource` object that includes the ID of the object, the IRI to it (which includes the name for the object collection and hence a way to tell what is the object) and the object data itself.

It also aims to fix other important issues with Version resources:

- [x] No way to tell what the embedded object in a `Version` resource output is.
- [x] Not serving the full object data as it was at that point in the version resource.
- [ ] No clear spec for how to work with `Version` resources and `X` versioned resource versions.
See inspiration from AWS' S3 Version API:\
 - Version resource collection: https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectVersions.html
 - X Versioned resource version: https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObject.html#API_GetObject_RequestSyntax