### PR TITLE
[feat] Update workflows to PHP 8.3

### DIFF
--- a/.github/workflows/php-cs-fixer.yaml
+++ b/.github/workflows/php-cs-fixer.yaml
@@ -4,10 +4,10 @@ jobs:
   php-cs-fixer:
     runs-on: "ubuntu-latest"
     steps:
-      - name: Setup PHP 8.2
+      - name: Setup PHP 8.3
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'
+          php-version: '8.3'
           tools: php-cs-fixer:3.64
 
       - name: Checkout repository

--- a/.github/workflows/phpunit.yaml
+++ b/.github/workflows/phpunit.yaml
@@ -18,14 +18,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install dependencies
-        run: composer install --prefer-dist --no-progress --no-suggest
+      - uses: php-actions/composer@v6
 
       - name: PHPUnit
         uses: php-actions/phpunit@v4
         env:
           DATABASE_URL: mysql://root:goteo@127.0.0.1:${{ job.services.mariadb.ports['3306'] }}/goteo
         with:
-          php_version: 8.2
+          php_version: 8.3
           php_extensions: pdo_mysql
           configuration:  phpunit.xml.dist


### PR DESCRIPTION
Updates and locks PHP version of the GitHub action workflows to 8.3, which is the same version we are using in the Dockerfile image.