### PR TITLE
[fix] Add OpenSSL ini config for PHP with custom cafile path

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # The v4 API
 This repository holds the code for the Goteo **v4** API.
 
+> **NOTE**: Review the trusted certificates by OpenSSL. See: https://github.com/GoteoFoundation/v4/issues/43
+
 ## Installation
 This application requires [Docker](https://docs.docker.com/get-docker/) and the [Docker Compose](https://docs.docker.com/compose/install/) plugin.
 
@@ -31,7 +33,7 @@ UID=1001
 GID=1001
 
 APP_HTTP_PORT=8080
-APP_HTTPS_PORT=8433
+APP_HTTPS_PORT=8443
 ```
 
 Then feed your custom env vars to Compose:
@@ -41,7 +43,7 @@ docker compose --env-file .env.local up -d --build
 
 - Option B. Passing the variables through the shell.
 ```shell
-export APP_HTTP_PORT=8080 && export APP_HTTPS_PORT=8433
+export APP_HTTP_PORT=8080 && export APP_HTTPS_PORT=8443
 
 # Dynamic user and group id
 export UID=$(id -u) && export GID=$(id -g)
@@ -73,7 +75,7 @@ bin/docker php bin/console app:gateways:setup
 
 ## Usage
 
-The app should be live at [http://localhost:8091](http://localhost:8091) (or your specified ports). Keep in mind that the API address is [/v4](http://localhost:8091/v4).
+The app should be live at [http://localhost:8090](http://localhost:8090) (or your specified ports). Keep in mind that the API address is [/v4](http://localhost:8090/v4).
 
 You can access a real-time build of the OpenAPI spec file for v4 at [http://localhost:8090/v4/docs.json](http://localhost:8090/v4/docs.json), to be used, for example, with API development suites such as Hoppscotch. This file will be up to date with most of your latest changes.
 
@@ -83,6 +85,7 @@ For quick Docker access you can use the `bin/docker` shortcut to quickly `exec` 
 
 - Login to mysql CLI: `bin/docker mariadb mysql -u goteo -pgoteo goteo`
 - Debug the symfony services: `bin/docker php bin/console debug:container`
+- List app custom commands: `bin/docker php bin/console list app`
 
 ## Testing
 

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,6 +1,7 @@
 services:
   php:
     volumes:
+      # ./docker/php/ssl/ca-certificates.crt:/etc/ssl/certs/ca-certificates.crt:ro
       - ./docker/php/conf.d/opcache.dev.ini:/usr/local/etc/php/conf.d/opcache.ini:ro
       - ./docker/php/conf.d/xdebug.dev.ini:/usr/local/etc/php/conf.d/xdebug.ini:ro
     extra_hosts:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,8 @@ services:
     container_name: goteo-v4-php
     volumes:
       - .:/app
+      - ./docker/php/ssl/ca-bundle.crt:/etc/ssl/ca-bundle.crt:ro
+      - ./docker/php/conf.d/openssl.ini:/usr/local/etc/php/conf.d/openssl.ini:ro
       - ./docker/php/conf.d/opcache.ini:/usr/local/etc/php/conf.d/opcache.ini:ro
 
   nginx:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,6 @@ services:
     container_name: goteo-v4-php
     volumes:
       - .:/app
-      - ./docker/php/ssl/ca-bundle.crt:/etc/ssl/ca-bundle.crt:ro
       - ./docker/php/conf.d/openssl.ini:/usr/local/etc/php/conf.d/openssl.ini:ro
       - ./docker/php/conf.d/opcache.ini:/usr/local/etc/php/conf.d/opcache.ini:ro
 

--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -19,6 +19,8 @@ RUN docker-php-ext-install \
 
 COPY --from=composer:lts /usr/bin/composer /usr/local/bin/composer
 
+RUN curl --remote-name https://curl.se/ca/cacert.pem \
+    && mv cacert.pem /etc/ssl/certs/ca-certificates.crt
 
 FROM base AS dev
 

--- a/docker/php/conf.d/openssl.ini
+++ b/docker/php/conf.d/openssl.ini
@@ -1,2 +1,2 @@
 [openssl]
-openssl.cafile=/etc/ssl/ca-bundle.crt
+openssl.cafile=/etc/ssl/certs/ca-certificates.crt

--- a/docker/php/conf.d/openssl.ini
+++ b/docker/php/conf.d/openssl.ini
@@ -1,0 +1,2 @@
+[openssl]
+openssl.cafile=/etc/ssl/ca-bundle.crt

--- a/docker/php/ssl/.gitignore
+++ b/docker/php/ssl/.gitignore
@@ -1,0 +1,1 @@
+ca-bundle.crt

--- a/docker/php/ssl/.gitignore
+++ b/docker/php/ssl/.gitignore
@@ -1,1 +1,1 @@
-ca-bundle.crt
+*.crt


### PR DESCRIPTION
Solution for https://github.com/GoteoFoundation/v4/issues/43, a path is set to use a custom `cafile` for OpenSSL.

@davidbeig can you help me put the code in place to get the file from https://curl.se/docs/caextract.html in the docker build step? Thank you!

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209098345884093