### PR TITLE
 [fix] Same PHP version and extensions value to php-actions/composer and php-actions/phpunit

### DIFF
--- a/.github/workflows/phpunit.yaml
+++ b/.github/workflows/phpunit.yaml
@@ -1,5 +1,11 @@
 name: PHPUnit
+
 on: [push]
+
+env:
+  PHP_VERSION: '8.3'
+  PHP_EXTENSIONS: pdo_mysql
+
 jobs:
   phpunit:
     runs-on: ubuntu-latest
@@ -19,12 +25,15 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: php-actions/composer@v6
+        with:
+          php_version: ${{ env.PHP_VERSION }}
+          php_extensions: ${{ env.PHP_EXTENSIONS }}
 
       - name: PHPUnit
         uses: php-actions/phpunit@v4
         env:
           DATABASE_URL: mysql://root:goteo@127.0.0.1:${{ job.services.mariadb.ports['3306'] }}/goteo
         with:
-          php_version: 8.3
-          php_extensions: pdo_mysql
+          php_version: ${{ env.PHP_VERSION }}
+          php_extensions: ${{ env.PHP_EXTENSIONS }}
           configuration:  phpunit.xml.dist


### PR DESCRIPTION
Updates PHPUnit CI pipeline to allow steps to share info on PHP version and extensions.