### PR TITLE
[feat] Pumping nuances

### DIFF
--- a/src/Benzina/ProjectsBudgetPump.php
+++ b/src/Benzina/ProjectsBudgetPump.php
@@ -19,6 +19,8 @@ class ProjectsBudgetPump implements PumpInterface
     use DoctrinePumpTrait;
     use LocalizedPumpTrait;
 
+    private const MAX_INT = 2147483647;
+
     private const COST_KEYS = [
         'id',
         'project',
@@ -64,7 +66,7 @@ class ProjectsBudgetPump implements PumpInterface
         $budgetItem->setType($this->getCostType($record));
         $budgetItem->setTitle($record['cost']);
         $budgetItem->setDescription($record['description'] ?? $record['cost']);
-        $budgetItem->setMoney(new EmbeddableMoney($record['amount'] * 100, 'EUR'));
+        $budgetItem->setMoney($this->getCostMoney($record['amount'], 'EUR'));
         $budgetItem->setDeadline($this->getDeadline($record));
 
         $this->setPreventFlushAndClear(true);
@@ -113,5 +115,16 @@ class ProjectsBudgetPump implements PumpInterface
         $query->execute(['cost' => $budgetItem->getMigratedId()]);
 
         return $query->fetchAll();
+    }
+
+    private function getCostMoney(int $amount, string $currency): EmbeddableMoney
+    {
+        $amount = $amount * 100;
+
+        if ($amount >= self::MAX_INT) {
+            $amount = self::MAX_INT;
+        }
+
+        return new EmbeddableMoney($amount, $currency);
     }
 }

--- a/src/Benzina/UsersPump.php
+++ b/src/Benzina/UsersPump.php
@@ -59,7 +59,7 @@ class UsersPump implements PumpInterface
             $handle = UserService::asHandle($record['email']);
         }
 
-        return \sprintf('%s_%d', $handle, $this->userCount % 100);
+        return \sprintf('%s_%02d', $handle, $this->userCount % 100);
     }
 
     private function getDateCreated(array $record): \DateTime

--- a/src/Service/UserService.php
+++ b/src/Service/UserService.php
@@ -18,8 +18,8 @@ class UserService
             $value = $matches[0];
         }
 
-        // Only lowercase a-z, numbers and underscore in user handles
-        $value = \preg_replace('/[^a-z0-9_]/', '_', \strtolower($value));
+        // Only lowercase a-z, numbers, underscore and middle dots in user handles
+        $value = \preg_replace('/[^a-z0-9_.]|^\.|\.$/', '_', \strtolower($value));
 
         // Min length 4
         $value = \str_pad($value, 4, '_');


### PR DESCRIPTION
- [x] Allowed user handles to have `.` as long as it's not at start or end of string
- [x] Increased user sequence discriminator string space to two digits.
- [x] Allowed draft or in edition projects to be pumped.
- [x] General defense against new bad data.  