### PR TITLE
feat: only pull exchange sources data when actually needed

### DIFF
--- a/src/Money/Conversion/Exchange/AbstractExchange.php
+++ b/src/Money/Conversion/Exchange/AbstractExchange.php
@@ -19,12 +19,20 @@ abstract class AbstractExchange implements ExchangeInterface
     protected CurrencyConverter $converter;
     protected ExchangeRateProvider $provider;
 
+    /**
+     * Here is where your implementation should pull the data from its sources.
+     * The methods `convert`, `getConversionRate`, and `getConversionDate` will call this method before making any operation.
+     */
+    abstract protected function load(): void;
+
     public function convert(
         MoneyInterface $from,
         string $toCurrency,
         ?Context $context = null,
         RoundingMode $roundingMode = RoundingMode::UP,
     ): MoneyInterface {
+        $this->load();
+
         $converted = $this->converter->convert(
             MoneyService::toBrick($from),
             $toCurrency,
@@ -48,11 +56,15 @@ abstract class AbstractExchange implements ExchangeInterface
 
     public function getConversionRate(string $fromCurrency, string $toCurrency): float
     {
+        $this->load();
+
         return $this->provider->getExchangeRate($fromCurrency, $toCurrency)->toFloat();
     }
 
     public function getConversionDate(string $fromCurrency, string $toCurrency): string
     {
+        $this->load();
+
         return $this->date;
     }
 }

--- a/src/Money/Conversion/Exchange/EuropeanCentralBankExchange.php
+++ b/src/Money/Conversion/Exchange/EuropeanCentralBankExchange.php
@@ -2,10 +2,12 @@
 
 namespace App\Money\Conversion\Exchange;
 
+use App\Money\MoneyInterface;
+use Brick\Math\RoundingMode;
+use Brick\Money\Context;
 use Brick\Money\CurrencyConverter;
 use Brick\Money\ExchangeRateProvider\BaseCurrencyProvider;
 use Brick\Money\ExchangeRateProvider\ConfigurableProvider;
-use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 use Symfony\Contracts\Cache\CacheInterface;
 use Symfony\Contracts\Cache\ItemInterface;
 
@@ -32,12 +34,22 @@ class EuropeanCentralBankExchange extends AbstractExchange
 
     public const ECB_TIMEZONE = 'Europe/Berlin';
 
-    private CacheInterface $cache;
+    public function __construct(
+        private CacheInterface $cache,
+    ) {}
 
-    public function __construct()
+    public function getName(): string
     {
-        $this->cache = new FilesystemAdapter();
+        return self::NAME;
+    }
 
+    public function getWeight(): int
+    {
+        return self::WEIGHT;
+    }
+
+    public function convert(MoneyInterface $from, string $toCurrency, ?Context $context = null, RoundingMode $roundingMode = RoundingMode::UP): MoneyInterface
+    {
         $data = $this->getData();
 
         $provider = new ConfigurableProvider();
@@ -49,16 +61,8 @@ class EuropeanCentralBankExchange extends AbstractExchange
         $this->date = $data['@attributes']['time'];
         $this->provider = new BaseCurrencyProvider($provider, self::ISO_4217);
         $this->converter = new CurrencyConverter($this->provider);
-    }
 
-    public function getName(): string
-    {
-        return self::NAME;
-    }
-
-    public function getWeight(): int
-    {
-        return self::WEIGHT;
+        return parent::convert($from, $toCurrency, $context, $roundingMode);
     }
 
     public function getData(): array
@@ -111,11 +115,14 @@ class EuropeanCentralBankExchange extends AbstractExchange
 
     private function getDataCached(): array
     {
-        $data = $this->cache->get(self::NAME, function (ItemInterface $item): array {
-            $item->expiresAfter(self::ECB_DATA_TTL);
+        $data = $this->cache->get(
+            self::NAME,
+            function (ItemInterface $item): array {
+                $item->expiresAfter(self::ECB_DATA_TTL);
 
-            return $this->getDataLatest();
-        });
+                return $this->getDataLatest();
+            }
+        );
 
         if (!$data || empty($data['@attributes']['time'])) {
             throw new \Exception('Could not retrieve cached data');

--- a/src/Money/Conversion/Exchange/EuropeanCentralBankExchange.php
+++ b/src/Money/Conversion/Exchange/EuropeanCentralBankExchange.php
@@ -2,9 +2,6 @@
 
 namespace App\Money\Conversion\Exchange;
 
-use App\Money\MoneyInterface;
-use Brick\Math\RoundingMode;
-use Brick\Money\Context;
 use Brick\Money\CurrencyConverter;
 use Brick\Money\ExchangeRateProvider\BaseCurrencyProvider;
 use Brick\Money\ExchangeRateProvider\ConfigurableProvider;
@@ -48,7 +45,7 @@ class EuropeanCentralBankExchange extends AbstractExchange
         return self::WEIGHT;
     }
 
-    public function convert(MoneyInterface $from, string $toCurrency, ?Context $context = null, RoundingMode $roundingMode = RoundingMode::UP): MoneyInterface
+    protected function load(): void
     {
         $data = $this->getData();
 
@@ -61,8 +58,6 @@ class EuropeanCentralBankExchange extends AbstractExchange
         $this->date = $data['@attributes']['time'];
         $this->provider = new BaseCurrencyProvider($provider, self::ISO_4217);
         $this->converter = new CurrencyConverter($this->provider);
-
-        return parent::convert($from, $toCurrency, $context, $roundingMode);
     }
 
     public function getData(): array

--- a/src/Money/Conversion/Exchange/FrankfurterExchange.php
+++ b/src/Money/Conversion/Exchange/FrankfurterExchange.php
@@ -2,9 +2,6 @@
 
 namespace App\Money\Conversion\Exchange;
 
-use App\Money\MoneyInterface;
-use Brick\Math\RoundingMode;
-use Brick\Money\Context;
 use Brick\Money\CurrencyConverter;
 use Brick\Money\ExchangeRateProvider\BaseCurrencyProvider;
 use Brick\Money\ExchangeRateProvider\ConfigurableProvider;
@@ -38,7 +35,7 @@ class FrankfurterExchange extends AbstractExchange
         private CacheInterface $cache,
     ) {}
 
-    public function convert(MoneyInterface $from, string $toCurrency, ?Context $context = null, RoundingMode $roundingMode = RoundingMode::UP): MoneyInterface
+    protected function load(): void
     {
         $data = $this->cache->get(
             self::NAME,
@@ -57,8 +54,6 @@ class FrankfurterExchange extends AbstractExchange
         $this->date = $data['date'];
         $this->provider = new BaseCurrencyProvider($provider, self::ISO_4217);
         $this->converter = new CurrencyConverter($this->provider);
-
-        return parent::convert($from, $toCurrency, $context, $roundingMode);
     }
 
     private function getDataLatest(): array

--- a/src/Money/Conversion/Exchange/FrankfurterExchange.php
+++ b/src/Money/Conversion/Exchange/FrankfurterExchange.php
@@ -2,9 +2,14 @@
 
 namespace App\Money\Conversion\Exchange;
 
+use App\Money\MoneyInterface;
+use Brick\Math\RoundingMode;
+use Brick\Money\Context;
 use Brick\Money\CurrencyConverter;
 use Brick\Money\ExchangeRateProvider\BaseCurrencyProvider;
 use Brick\Money\ExchangeRateProvider\ConfigurableProvider;
+use Psr\Cache\CacheItemInterface;
+use Symfony\Contracts\Cache\CacheInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 class FrankfurterExchange extends AbstractExchange
@@ -12,8 +17,11 @@ class FrankfurterExchange extends AbstractExchange
     private const NAME = 'frankfurter';
     private const WEIGHT = 200;
 
-    private const ENDPOINT = 'https://api.frankfurter.dev/v1/latest';
     private const ISO_4217 = 'EUR';
+
+    private const ENDPOINT = 'https://api.frankfurter.dev/v1/latest';
+
+    private const CACHE_TTL = 86400;
 
     public function getName(): string
     {
@@ -26,10 +34,20 @@ class FrankfurterExchange extends AbstractExchange
     }
 
     public function __construct(
-        HttpClientInterface $httpClient,
-    ) {
-        $response = $httpClient->request('GET', self::ENDPOINT);
-        $data = $response->toArray();
+        private HttpClientInterface $httpClient,
+        private CacheInterface $cache,
+    ) {}
+
+    public function convert(MoneyInterface $from, string $toCurrency, ?Context $context = null, RoundingMode $roundingMode = RoundingMode::UP): MoneyInterface
+    {
+        $data = $this->cache->get(
+            self::NAME,
+            function (CacheItemInterface $item) {
+                $item->expiresAfter(self::CACHE_TTL);
+
+                return $this->getDataLatest();
+            }
+        );
 
         $provider = new ConfigurableProvider();
         foreach ($data['rates'] as $currency => $rate) {
@@ -39,5 +57,14 @@ class FrankfurterExchange extends AbstractExchange
         $this->date = $data['date'];
         $this->provider = new BaseCurrencyProvider($provider, self::ISO_4217);
         $this->converter = new CurrencyConverter($this->provider);
+
+        return parent::convert($from, $toCurrency, $context, $roundingMode);
+    }
+
+    private function getDataLatest(): array
+    {
+        $response = $this->httpClient->request('GET', self::ENDPOINT);
+
+        return $response->toArray();
     }
 }

--- a/tests/Money/Conversion/EuropeanCentralBankExchangeTest.php
+++ b/tests/Money/Conversion/EuropeanCentralBankExchangeTest.php
@@ -5,15 +5,23 @@ namespace App\Tests\Money\Conversion;
 use App\Money\Conversion\Exchange\EuropeanCentralBankExchange;
 use App\Money\Money;
 use Brick\Money\Context\CustomContext;
-use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 
-class EuropeanCentralBankExchangeTest extends TestCase
+class EuropeanCentralBankExchangeTest extends KernelTestCase
 {
+    private EuropeanCentralBankExchange $exchange;
+
+    public function setUp(): void
+    {
+        self::bootKernel();
+
+        $this->exchange = static::getContainer()->get(EuropeanCentralBankExchange::class);
+    }
+
     public function testGetsData()
     {
-        $exchange = new EuropeanCentralBankExchange();
-        $exchangeData = $exchange->getData();
+        $exchangeData = $this->exchange->getData();
 
         $this->assertIsArray($exchangeData);
         $this->assertArrayHasKey('Cube', $exchangeData);
@@ -22,10 +30,9 @@ class EuropeanCentralBankExchangeTest extends TestCase
 
     public function testStoresDataInCache()
     {
-        $exchange = new EuropeanCentralBankExchange();
         $cache = new FilesystemAdapter();
 
-        $exchangeData = $cache->get($exchange->getName(), function (): false {
+        $exchangeData = $cache->get($this->exchange->getName(), function (): false {
             return false;
         });
 
@@ -37,11 +44,10 @@ class EuropeanCentralBankExchangeTest extends TestCase
 
     public function testConvertsWholeEuros()
     {
-        $exchange = new EuropeanCentralBankExchange();
         $context = new CustomContext(scale: 0, step: 1);
 
-        $this->assertEquals(100, $exchange->convert(new Money(100, 'JPY'), 'EUR', $context)->getAmount());
-        $this->assertEquals(100, $exchange->convert(new Money(150, 'JPY'), 'EUR', $context)->getAmount());
-        $this->assertEquals(100, $exchange->convert(new Money(700, 'CNY'), 'EUR', $context)->getAmount());
+        $this->assertEquals(100, $this->exchange->convert(new Money(100, 'JPY'), 'EUR', $context)->getAmount());
+        $this->assertEquals(100, $this->exchange->convert(new Money(150, 'JPY'), 'EUR', $context)->getAmount());
+        $this->assertEquals(100, $this->exchange->convert(new Money(700, 'CNY'), 'EUR', $context)->getAmount());
     }
 }

--- a/tests/Money/Conversion/EuropeanCentralBankExchangeTest.php
+++ b/tests/Money/Conversion/EuropeanCentralBankExchangeTest.php
@@ -6,7 +6,6 @@ use App\Money\Conversion\Exchange\EuropeanCentralBankExchange;
 use App\Money\Money;
 use Brick\Money\Context\CustomContext;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
-use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 
 class EuropeanCentralBankExchangeTest extends KernelTestCase
 {
@@ -23,20 +22,6 @@ class EuropeanCentralBankExchangeTest extends KernelTestCase
     {
         $exchangeData = $this->exchange->getData();
 
-        $this->assertIsArray($exchangeData);
-        $this->assertArrayHasKey('Cube', $exchangeData);
-        $this->assertArrayHasKey('@attributes', $exchangeData);
-    }
-
-    public function testStoresDataInCache()
-    {
-        $cache = new FilesystemAdapter();
-
-        $exchangeData = $cache->get($this->exchange->getName(), function (): false {
-            return false;
-        });
-
-        $this->assertNotFalse($exchangeData);
         $this->assertIsArray($exchangeData);
         $this->assertArrayHasKey('Cube', $exchangeData);
         $this->assertArrayHasKey('@attributes', $exchangeData);


### PR DESCRIPTION
- [x] Fixed issue causing entire app to block when one of the exchanges data source was down
- [x] Added 1-day cache to `FrankfurterExchange`