### PR TITLE
Feat/consented oauth clients

### DIFF
--- a/config/packages/league_oauth2_server.yaml
+++ b/config/packages/league_oauth2_server.yaml
@@ -1,4 +1,6 @@
 league_oauth2_server:
+    client:
+        classname: App\Entity\OAuth2Client
     authorization_server:
         private_key: '%env(resolve:OAUTH_PRIVATE_KEY)%'
         private_key_passphrase: '%env(resolve:OAUTH_PASSPHRASE)%'

--- a/migrations/Version20260413141741.php
+++ b/migrations/Version20260413141741.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260413141741 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add is_consented column to oauth2_clients table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE oauth2_client ADD is_consented TINYINT(1) NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE oauth2_client DROP is_consented');
+    }
+}

--- a/src/Command/OAuth2ConsentClientCommand.php
+++ b/src/Command/OAuth2ConsentClientCommand.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace App\Command;
+
+use League\Bundle\OAuth2ServerBundle\Manager\ClientManagerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+#[AsCommand(name: 'app:oauth2-server:consent-client', description: 'Consents an OAuth2 client')]
+class OAuth2ConsentClientCommand extends Command
+{
+    /**
+     * @var ClientManagerInterface
+     */
+    private $clientManager;
+
+    public function __construct(ClientManagerInterface $clientManager)
+    {
+        parent::__construct();
+
+        $this->clientManager = $clientManager;
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->setDescription('Consents an OAuth2 client, allowing it to skip the consent screen')
+
+            ->addOption('consent', null, InputOption::VALUE_NEGATABLE, 'Consent the client')
+
+            ->addArgument('identifier', InputArgument::REQUIRED, 'The client identifier')
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        /** @var \App\Entity\OAuth2Client */
+        $client = $this->clientManager->find($input->getArgument('identifier'));
+        if (!$client) {
+            $io->error(\sprintf('OAuth2 client identified as "%s" does not exist.', $input->getArgument('identifier')));
+
+            return 1;
+        }
+
+        $client->setConsented($this->getClientConsentedFromInput($input, $client->isConsented()));
+
+        $this->clientManager->save($client);
+
+        $io->success('OAuth2 client updated successfully.');
+
+        return 0;
+    }
+
+    private function getClientConsentedFromInput(InputInterface $input, bool $actual): bool
+    {
+        $active = $actual;
+
+        if ($input->getOption('consent')) {
+            $active = true;
+        }
+
+        if ($input->getOption('no-consent')) {
+            $active = false;
+        }
+
+        return $active;
+    }
+}

--- a/src/Controller/SecurityController.php
+++ b/src/Controller/SecurityController.php
@@ -2,7 +2,7 @@
 
 namespace App\Controller;
 
-use App\EventListener\LeaugeOAuth2AuthorizationListener;
+use App\EventListener\LeagueOAuth2AuthorizationListener;
 use KnpU\OAuth2ClientBundle\Client\ClientRegistry;
 use League\Bundle\OAuth2ServerBundle\Manager\ClientManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -46,7 +46,7 @@ class SecurityController extends AbstractController
     {
         if ($request->getMethod() === Request::METHOD_POST) {
             $request->getSession()->set(
-                LeaugeOAuth2AuthorizationListener::AUTHORIZATION_RESULT,
+                LeagueOAuth2AuthorizationListener::AUTHORIZATION_RESULT,
                 $request->get('_consent') ?? false
             );
 

--- a/src/Entity/OAuth2Client.php
+++ b/src/Entity/OAuth2Client.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity;
+
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use League\Bundle\OAuth2ServerBundle\Model\AbstractClient;
+
+#[ORM\Entity()]
+class OAuth2Client extends AbstractClient
+{
+    #[ORM\Id]
+    #[ORM\Column(type: Types::STRING, length: 32)]
+    protected string $identifier;
+
+    #[ORM\Column(type: Types::BOOLEAN)]
+    private bool $isConsented = false;
+
+    /**
+     * Returns true if the client can skip the consent page.
+     */
+    public function isConsented(): bool
+    {
+        return $this->isConsented;
+    }
+
+    public function setConsented(bool $isConsented): void
+    {
+        $this->isConsented = $isConsented;
+    }
+}

--- a/src/EventListener/LeagueOAuth2AuthorizationListener.php
+++ b/src/EventListener/LeagueOAuth2AuthorizationListener.php
@@ -21,6 +21,15 @@ final class LeagueOAuth2AuthorizationListener
     #[AsEventListener(event: OAuth2Events::AUTHORIZATION_REQUEST_RESOLVE)]
     public function onAuthorizationRequestResolve(AuthorizationRequestResolveEvent $event): void
     {
+        /** @var \App\Entity\OAuth2Client */
+        $client = $event->getClient();
+
+        if ($client->isConsented()) {
+            $event->resolveAuthorization(true);
+
+            return;
+        }
+
         $request = $this->requestStack->getCurrentRequest();
 
         if ($request->getSession()->has(self::AUTHORIZATION_RESULT)) {

--- a/src/EventListener/LeagueOAuth2AuthorizationListener.php
+++ b/src/EventListener/LeagueOAuth2AuthorizationListener.php
@@ -9,7 +9,7 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
-final class LeaugeOAuth2AuthorizationListener
+final class LeagueOAuth2AuthorizationListener
 {
     public const string AUTHORIZATION_RESULT = 'oauth2.authorization_result';
 


### PR DESCRIPTION
- [x] Use custom entity class `App\Entity\OAuth2Client` with extra `isConsented` property
- [x] Added command `app:oauth2-server:consent-client` to update `isConsented` value of OAuth2 clients
- [x] Allowed consented clients to skip the consent screen step and authorize straight after login